### PR TITLE
feat(iac): created the iam architecture

### DIFF
--- a/iac/gcp/tofu/_env/group.hcl
+++ b/iac/gcp/tofu/_env/group.hcl
@@ -1,0 +1,19 @@
+/**
+ * terragrunt function to create a group
+ *
+ * Created April 18th, 2025
+ * @author: ywarezk 
+ */
+
+locals {
+  customer_id = yamldecode(file(find_in_parent_folders("common_vars.yaml"))).customer_id
+}
+
+terraform {
+  source = "tfr:///terraform-google-modules/group/google?version=0.7.0"
+}
+
+inputs = {
+  customer_id = local.customer_id
+  owners      = ["az-k8s-iam@academeez-k8s-flux-iam-c55b.iam.gserviceaccount.com"]
+}

--- a/iac/gcp/tofu/_env/service-account.hcl
+++ b/iac/gcp/tofu/_env/service-account.hcl
@@ -1,0 +1,14 @@
+/**
+ * terragrunt function to create a service account
+ *
+ * Created April 18th, 2025
+ * @author: ywarezk 
+ */
+
+terraform {
+  source = "tfr:///terraform-google-modules/service-accounts/google?version=4.5.3"
+}
+
+inputs = {
+  prefix = "az-k8s"
+}

--- a/iac/gcp/tofu/iam/folder/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/folder/.terraform.lock.hcl
@@ -1,0 +1,55 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = ">= 6.0.0, < 7.0.0"
+  hashes = [
+    "h1:pMSQxf9MRGrylCl5IbbzoiN1g2hQMIS2LbCZ89nc/Ss=",
+    "zh:22c34039642fa56b912e89451f5c44e574813d67ab0759fe36d5d3fa2ca5cdc6",
+    "zh:5064ba937b539ba89738ba5a7e8355d12feaf68584f901d7d55ffbd64183ba4f",
+    "zh:6350440669d41a3b98d877a65b55176cf93e2cc86c15a5904775587546874013",
+    "zh:63f61dbbe72fd1bf221e8b84ed5fda5afd958ff50267f804a6648deb3172eba0",
+    "zh:7e657c3a802febe7299cee481613f80b6acfc2d19a3957306350f03c4782966a",
+    "zh:8ebabf9f3a6f7b29b3cf7d63f69d5576f3bac6e1d5187d52093bece12a282c68",
+    "zh:b2126150d7d6099de4220b12a704f7bda6eb8e0dc95d1e78cfdb12594a5603fa",
+    "zh:b5154becbdb228b55c811376cf1bd023e5a62dc5b0e075d4e17ca565bb1cf9b5",
+    "zh:e3985b7fe814b87bfc36d743320762d314798ada47c7d91f7be7eb95f14ce59f",
+    "zh:f64bbdf8f0b6ff3d5696cfc2e1675d3b65dc7cc821cc83f1e584f5e0e34d1749",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version = "6.29.0"
+  hashes = [
+    "h1:Vw5+HajwxG2Yu58CDnsZ1zAm2d3j9CsbB7ICK+yA9TY=",
+    "zh:0f3070ce2eaafb7d3b6c479552310aa9c255e496a8dc9662bc0743160800d955",
+    "zh:33831afc143e900ec1d3c8910cbccb1fb30a059d41f3c925544adb7ef1125b9b",
+    "zh:546381b757a39ae1f5a7c5f2df18b465bb5d24673e1116013647960c284dedcb",
+    "zh:68b34f5d885e016478229fc8aa781b4803be43d5a28ddb9f786e068b3281203c",
+    "zh:6ee2bb59ad57bdbd23188fb850a18b5154b142e2423050349a020908d4f04d76",
+    "zh:779cb8f26f8a6b273fb0cc9be1177cd2d2bd7198ccbcac2b221a686c6eb80c61",
+    "zh:abfd416b0438f2fa5dfba5c48756c752b10f44badb0803031011eb508fa69a8d",
+    "zh:b2d9c637400b63efdb308d8d3ab9c156ab3ccdfdd698dbdb9b816c955e5937f1",
+    "zh:bca558543f53ea841319892606258e9834144328d551feec039b83fe8a109be0",
+    "zh:c3a515a0ede9224606ad851106ecd21a7ec503a925abd2b0ddd8d60abb4325a5",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.7.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:HxqzkbeZlX7e/UfK6DA6SBYmd1+mURGRsRQHimwrpEM=",
+    "zh:1011387a5127d46e2bf0bd5124a8469506272b2110613d9eb80d178f94bd67a9",
+    "zh:28785c36d6dc331d49e8bf6a30d4ba21ae4378f5d98c43c0aeb42f51efb2e42f",
+    "zh:50fc0e52f0255950404681455420344a16263f91622bd481954606e6e3be9eb2",
+    "zh:563f22c53f40e41cfffdcfac32a9292292c10582183c3f1dd85770cf806bfce9",
+    "zh:586a5615898d369374d4bd7d70bc013cffe7553d3e14638f169a3f745665fee1",
+    "zh:6275f6e5697993048ac088715484a9a5e919682651e098a5ac31e567216bf102",
+    "zh:95a44bb3f012da1e036936d60df2d08f5942a96cb912fc23432d2ee050857527",
+    "zh:a5fe6b0e586645a88d98738739fec40fd7ad83dbc63fe66ff6327aee2dc07f11",
+    "zh:ea57886899b6baf466f3ff978f4482d2fd7fa049c42509cc819431375cddd5bd",
+    "zh:f021cfbe23bdb32738f170c1ae736ffb769a2fa3dcafd0f9906155c2e21377e4",
+  ]
+}

--- a/iac/gcp/tofu/iam/folder/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/folder/terragrunt.hcl
@@ -1,0 +1,27 @@
+/**
+ * This will create the iam folder
+ * All iam cloud resources will be grouped under this folder
+ * root -> iam
+ *
+ * Created April 18th, 2025
+ * @author: ywarezk
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "folder" {
+  path = "${dirname(find_in_parent_folders())}/_env/folder.hcl"
+}
+
+# since this folder is under the root folder we will use dependency to get the parent folder
+dependency "root_folder" {
+  config_path = "../../common/folders/root"
+}
+
+inputs = {
+  parent              = dependency.root_folder.outputs.id
+  deletion_protection = false
+  names               = ["iam2"]
+}

--- a/iac/gcp/tofu/iam/groups/admin/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/groups/admin/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:pMSQxf9MRGrylCl5IbbzoiN1g2hQMIS2LbCZ89nc/Ss=",
+    "zh:22c34039642fa56b912e89451f5c44e574813d67ab0759fe36d5d3fa2ca5cdc6",
+    "zh:5064ba937b539ba89738ba5a7e8355d12feaf68584f901d7d55ffbd64183ba4f",
+    "zh:6350440669d41a3b98d877a65b55176cf93e2cc86c15a5904775587546874013",
+    "zh:63f61dbbe72fd1bf221e8b84ed5fda5afd958ff50267f804a6648deb3172eba0",
+    "zh:7e657c3a802febe7299cee481613f80b6acfc2d19a3957306350f03c4782966a",
+    "zh:8ebabf9f3a6f7b29b3cf7d63f69d5576f3bac6e1d5187d52093bece12a282c68",
+    "zh:b2126150d7d6099de4220b12a704f7bda6eb8e0dc95d1e78cfdb12594a5603fa",
+    "zh:b5154becbdb228b55c811376cf1bd023e5a62dc5b0e075d4e17ca565bb1cf9b5",
+    "zh:e3985b7fe814b87bfc36d743320762d314798ada47c7d91f7be7eb95f14ce59f",
+    "zh:f64bbdf8f0b6ff3d5696cfc2e1675d3b65dc7cc821cc83f1e584f5e0e34d1749",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.29.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:Vw5+HajwxG2Yu58CDnsZ1zAm2d3j9CsbB7ICK+yA9TY=",
+    "zh:0f3070ce2eaafb7d3b6c479552310aa9c255e496a8dc9662bc0743160800d955",
+    "zh:33831afc143e900ec1d3c8910cbccb1fb30a059d41f3c925544adb7ef1125b9b",
+    "zh:546381b757a39ae1f5a7c5f2df18b465bb5d24673e1116013647960c284dedcb",
+    "zh:68b34f5d885e016478229fc8aa781b4803be43d5a28ddb9f786e068b3281203c",
+    "zh:6ee2bb59ad57bdbd23188fb850a18b5154b142e2423050349a020908d4f04d76",
+    "zh:779cb8f26f8a6b273fb0cc9be1177cd2d2bd7198ccbcac2b221a686c6eb80c61",
+    "zh:abfd416b0438f2fa5dfba5c48756c752b10f44badb0803031011eb508fa69a8d",
+    "zh:b2d9c637400b63efdb308d8d3ab9c156ab3ccdfdd698dbdb9b816c955e5937f1",
+    "zh:bca558543f53ea841319892606258e9834144328d551feec039b83fe8a109be0",
+    "zh:c3a515a0ede9224606ad851106ecd21a7ec503a925abd2b0ddd8d60abb4325a5",
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/admin/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/groups/admin/terragrunt.hcl
@@ -1,0 +1,27 @@
+/**
+ * this will create the admin group
+ * Members of the admin group can:
+ * - Create and manage groups
+ * - Create and manage service accounts under the iam project
+ * - Create and manage roles under the course folder
+ *
+ * Created April 18th, 2025
+ * @author: ywarezk
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "group" {
+  path = "${dirname(find_in_parent_folders())}/_env/group.hcl"
+}
+
+inputs = {
+  description  = "Admin group is managing iam roles, groups, and gcp service accounts"
+  display_name = "Academeez K8s Flux Admin Group"
+  id           = "academeez-k8s-flux-admin@academeez.com"
+  members = [
+    "k8s-flux@academeez.com"
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/developers/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/groups/developers/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.30.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:vCUdTd378bnUIfiYvpPD8llQvPtQauadWKhnovSWMIE=",
+    "zh:0c79f7803f98651a5e22ba68f49623e6efddd603a6b7110d9d7b4955155a8eaf",
+    "zh:0fa4896cf880392b3b422b3151d237858aefc7f887710e955489691267c4c055",
+    "zh:1de84a8c628ec78b33058deb033d3ae77a4f5f67dfe3182f946a5c1bfeabd63d",
+    "zh:464fab03cdcfd9670810399f7307f6067281b3b5bf03e0a54a688fbc575adc66",
+    "zh:79425da1372e470b91c12ba326a530cf9d84221649ab8fb0ddeaddaf3208d6f6",
+    "zh:a26af9b468cdb9b3361bc2f575b185dde27deef8a2993c7667b645c21b77cc27",
+    "zh:c207fc074e9ed9c15e35efa0ecd3229d73e97685b386e8391b846bc0e59c85b2",
+    "zh:c3306fb116bcb47b0bbb659c84144a4a06fe5478c4d3cdf620d5dd027d603b89",
+    "zh:d63ada43c39cbd121ec97de121264fb422f964ac828c5c58b7581b8e7d4ea11b",
+    "zh:ecd61ad75f39be3fdc873a5b47ce65176ab046a5e08cf9cf7e0ed6d508f065f5",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.30.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:Lks4q4F/CfxWlirUY46SD6ZGbC0C3d5DQWpyTXiPIRI=",
+    "zh:4d3fff2fad73d36e58989beff2bfe19bb8258cdaa64072baa562370744110210",
+    "zh:54d7aaa9a9c6f25a8bee38d56e1bbc9f67edeae2caac7bddd27f2ef2d930a4dd",
+    "zh:5cc6149e23b798951aa7d4ffa6b5bd7b2cc3bc0b04d7f912eee44a594e95c669",
+    "zh:697817d0e03f34022620e8c81ac38f1c9c65f2408621ee3bd57aca65dbd53a84",
+    "zh:70d477c5b4d2a46b3137a662b1051bf6624af3738fb357fc6744f32191c09473",
+    "zh:896d18f08c28b0595119b7e81a7341c0b1941ed7d240262b9ad921cb5dfff048",
+    "zh:b58408f23b18012eba2be7a6737e1216f320ab6d3838892d583b83e3c61745c9",
+    "zh:c62adb52be25a1058fa892b69143d1e8f3d77c06048e59ba7824a81f9583dbcb",
+    "zh:cb8c939afd3efe8be7224cb8955cabe417503cc36b7fde44e69219ac969f79d2",
+    "zh:d1a3b3e9d173f311e3ac8f3477712fc633af38e6c782f6fe7144bbe23ecdefff",
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/developers/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/groups/developers/terragrunt.hcl
@@ -1,0 +1,25 @@
+/**
+ * this will create the developers group
+ * The developers group can be users of the staging db and users of gke
+ * They cannot create cloud resources
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "group" {
+  path = "${dirname(find_in_parent_folders())}/_env/group.hcl"
+}
+
+inputs = {
+  description  = "Developers group"
+  display_name = "Academeez K8s Flux Developers Group"
+  id           = "academeez-k8s-flux-developers@academeez.com"
+  members = [
+    "k8s-flux@academeez.com"
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/devops/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/groups/devops/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.30.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:vCUdTd378bnUIfiYvpPD8llQvPtQauadWKhnovSWMIE=",
+    "zh:0c79f7803f98651a5e22ba68f49623e6efddd603a6b7110d9d7b4955155a8eaf",
+    "zh:0fa4896cf880392b3b422b3151d237858aefc7f887710e955489691267c4c055",
+    "zh:1de84a8c628ec78b33058deb033d3ae77a4f5f67dfe3182f946a5c1bfeabd63d",
+    "zh:464fab03cdcfd9670810399f7307f6067281b3b5bf03e0a54a688fbc575adc66",
+    "zh:79425da1372e470b91c12ba326a530cf9d84221649ab8fb0ddeaddaf3208d6f6",
+    "zh:a26af9b468cdb9b3361bc2f575b185dde27deef8a2993c7667b645c21b77cc27",
+    "zh:c207fc074e9ed9c15e35efa0ecd3229d73e97685b386e8391b846bc0e59c85b2",
+    "zh:c3306fb116bcb47b0bbb659c84144a4a06fe5478c4d3cdf620d5dd027d603b89",
+    "zh:d63ada43c39cbd121ec97de121264fb422f964ac828c5c58b7581b8e7d4ea11b",
+    "zh:ecd61ad75f39be3fdc873a5b47ce65176ab046a5e08cf9cf7e0ed6d508f065f5",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.30.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:Lks4q4F/CfxWlirUY46SD6ZGbC0C3d5DQWpyTXiPIRI=",
+    "zh:4d3fff2fad73d36e58989beff2bfe19bb8258cdaa64072baa562370744110210",
+    "zh:54d7aaa9a9c6f25a8bee38d56e1bbc9f67edeae2caac7bddd27f2ef2d930a4dd",
+    "zh:5cc6149e23b798951aa7d4ffa6b5bd7b2cc3bc0b04d7f912eee44a594e95c669",
+    "zh:697817d0e03f34022620e8c81ac38f1c9c65f2408621ee3bd57aca65dbd53a84",
+    "zh:70d477c5b4d2a46b3137a662b1051bf6624af3738fb357fc6744f32191c09473",
+    "zh:896d18f08c28b0595119b7e81a7341c0b1941ed7d240262b9ad921cb5dfff048",
+    "zh:b58408f23b18012eba2be7a6737e1216f320ab6d3838892d583b83e3c61745c9",
+    "zh:c62adb52be25a1058fa892b69143d1e8f3d77c06048e59ba7824a81f9583dbcb",
+    "zh:cb8c939afd3efe8be7224cb8955cabe417503cc36b7fde44e69219ac969f79d2",
+    "zh:d1a3b3e9d173f311e3ac8f3477712fc633af38e6c782f6fe7144bbe23ecdefff",
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/devops/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/groups/devops/terragrunt.hcl
@@ -1,0 +1,26 @@
+/**
+ * this will create the devops group
+ * The devops group can create certain cloud resources like gke, dns, storage, etc.
+ * all in the realm of the course root folder
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ *
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "group" {
+  path = "${dirname(find_in_parent_folders())}/_env/group.hcl"
+}
+
+inputs = {
+  description  = "Devops group of developers"
+  display_name = "Academeez K8s Flux DevOps Group"
+  id           = "academeez-k8s-flux-devops@academeez.com"
+  members = [
+    "k8s-flux@academeez.com"
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/terragrunt/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/groups/terragrunt/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.30.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:vCUdTd378bnUIfiYvpPD8llQvPtQauadWKhnovSWMIE=",
+    "zh:0c79f7803f98651a5e22ba68f49623e6efddd603a6b7110d9d7b4955155a8eaf",
+    "zh:0fa4896cf880392b3b422b3151d237858aefc7f887710e955489691267c4c055",
+    "zh:1de84a8c628ec78b33058deb033d3ae77a4f5f67dfe3182f946a5c1bfeabd63d",
+    "zh:464fab03cdcfd9670810399f7307f6067281b3b5bf03e0a54a688fbc575adc66",
+    "zh:79425da1372e470b91c12ba326a530cf9d84221649ab8fb0ddeaddaf3208d6f6",
+    "zh:a26af9b468cdb9b3361bc2f575b185dde27deef8a2993c7667b645c21b77cc27",
+    "zh:c207fc074e9ed9c15e35efa0ecd3229d73e97685b386e8391b846bc0e59c85b2",
+    "zh:c3306fb116bcb47b0bbb659c84144a4a06fe5478c4d3cdf620d5dd027d603b89",
+    "zh:d63ada43c39cbd121ec97de121264fb422f964ac828c5c58b7581b8e7d4ea11b",
+    "zh:ecd61ad75f39be3fdc873a5b47ce65176ab046a5e08cf9cf7e0ed6d508f065f5",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.30.0"
+  constraints = ">= 3.67.0, < 7.0.0"
+  hashes = [
+    "h1:Lks4q4F/CfxWlirUY46SD6ZGbC0C3d5DQWpyTXiPIRI=",
+    "zh:4d3fff2fad73d36e58989beff2bfe19bb8258cdaa64072baa562370744110210",
+    "zh:54d7aaa9a9c6f25a8bee38d56e1bbc9f67edeae2caac7bddd27f2ef2d930a4dd",
+    "zh:5cc6149e23b798951aa7d4ffa6b5bd7b2cc3bc0b04d7f912eee44a594e95c669",
+    "zh:697817d0e03f34022620e8c81ac38f1c9c65f2408621ee3bd57aca65dbd53a84",
+    "zh:70d477c5b4d2a46b3137a662b1051bf6624af3738fb357fc6744f32191c09473",
+    "zh:896d18f08c28b0595119b7e81a7341c0b1941ed7d240262b9ad921cb5dfff048",
+    "zh:b58408f23b18012eba2be7a6737e1216f320ab6d3838892d583b83e3c61745c9",
+    "zh:c62adb52be25a1058fa892b69143d1e8f3d77c06048e59ba7824a81f9583dbcb",
+    "zh:cb8c939afd3efe8be7224cb8955cabe417503cc36b7fde44e69219ac969f79d2",
+    "zh:d1a3b3e9d173f311e3ac8f3477712fc633af38e6c782f6fe7144bbe23ecdefff",
+  ]
+}

--- a/iac/gcp/tofu/iam/groups/terragrunt/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/groups/terragrunt/terragrunt.hcl
@@ -1,0 +1,25 @@
+/**
+ * this will create the terragrunt group
+ * The terragrunt group will give permission to access the state bucket so a member can run terragrunt apply
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ *
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "group" {
+  path = "${dirname(find_in_parent_folders())}/_env/group.hcl"
+}
+
+inputs = {
+  description  = "Terragrunt group of developers that can run IAC"
+  display_name = "Academeez K8s Flux Terragrunt Group"
+  id           = "academeez-k8s-flux-terragrunt@academeez.com"
+  members = [
+    "k8s-flux@academeez.com"
+  ]
+}

--- a/iac/gcp/tofu/iam/iam.yaml
+++ b/iac/gcp/tofu/iam/iam.yaml
@@ -1,0 +1,8 @@
+# 
+# impersonate this service account when creating resources in this folder
+#
+# Created April 18th, 2025
+# @author: ywarezk
+# 
+
+email: "az-k8s-iam@academeez-k8s-flux-iam-c55b.iam.gserviceaccount.com"

--- a/iac/gcp/tofu/iam/permissions/iam/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/permissions/iam/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "6.29.0"
+  hashes = [
+    "h1:pMSQxf9MRGrylCl5IbbzoiN1g2hQMIS2LbCZ89nc/Ss=",
+    "zh:22c34039642fa56b912e89451f5c44e574813d67ab0759fe36d5d3fa2ca5cdc6",
+    "zh:5064ba937b539ba89738ba5a7e8355d12feaf68584f901d7d55ffbd64183ba4f",
+    "zh:6350440669d41a3b98d877a65b55176cf93e2cc86c15a5904775587546874013",
+    "zh:63f61dbbe72fd1bf221e8b84ed5fda5afd958ff50267f804a6648deb3172eba0",
+    "zh:7e657c3a802febe7299cee481613f80b6acfc2d19a3957306350f03c4782966a",
+    "zh:8ebabf9f3a6f7b29b3cf7d63f69d5576f3bac6e1d5187d52093bece12a282c68",
+    "zh:b2126150d7d6099de4220b12a704f7bda6eb8e0dc95d1e78cfdb12594a5603fa",
+    "zh:b5154becbdb228b55c811376cf1bd023e5a62dc5b0e075d4e17ca565bb1cf9b5",
+    "zh:e3985b7fe814b87bfc36d743320762d314798ada47c7d91f7be7eb95f14ce59f",
+    "zh:f64bbdf8f0b6ff3d5696cfc2e1675d3b65dc7cc821cc83f1e584f5e0e34d1749",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version = "6.29.0"
+  hashes = [
+    "h1:Vw5+HajwxG2Yu58CDnsZ1zAm2d3j9CsbB7ICK+yA9TY=",
+    "zh:0f3070ce2eaafb7d3b6c479552310aa9c255e496a8dc9662bc0743160800d955",
+    "zh:33831afc143e900ec1d3c8910cbccb1fb30a059d41f3c925544adb7ef1125b9b",
+    "zh:546381b757a39ae1f5a7c5f2df18b465bb5d24673e1116013647960c284dedcb",
+    "zh:68b34f5d885e016478229fc8aa781b4803be43d5a28ddb9f786e068b3281203c",
+    "zh:6ee2bb59ad57bdbd23188fb850a18b5154b142e2423050349a020908d4f04d76",
+    "zh:779cb8f26f8a6b273fb0cc9be1177cd2d2bd7198ccbcac2b221a686c6eb80c61",
+    "zh:abfd416b0438f2fa5dfba5c48756c752b10f44badb0803031011eb508fa69a8d",
+    "zh:b2d9c637400b63efdb308d8d3ab9c156ab3ccdfdd698dbdb9b816c955e5937f1",
+    "zh:bca558543f53ea841319892606258e9834144328d551feec039b83fe8a109be0",
+    "zh:c3a515a0ede9224606ad851106ecd21a7ec503a925abd2b0ddd8d60abb4325a5",
+  ]
+}

--- a/iac/gcp/tofu/iam/permissions/iam/main.tf
+++ b/iac/gcp/tofu/iam/permissions/iam/main.tf
@@ -1,0 +1,76 @@
+/**
+ * This will create the proper roles for the iam service account
+ * That service account can:
+ * - Create groups
+ * - Create service accounts
+ * - Create roles in the realm of the course
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+variable "iam_project" {
+	description = "The project id of the iam project"
+	type        = string
+}
+
+variable "iam_sa" {
+	description = "The iam service account email"
+	type        = string
+}
+
+variable "iam_sa_name" {
+	description = "The iam service account name"
+	type        = string
+}
+
+variable "root_folder" {
+	description = "The root folder id"
+	type        = string
+}
+
+variable "billing_project" {
+	description = "The billing project id"
+	type        = string
+}
+
+variable "admin_group" {
+	description = "The admin group email"
+	type        = string
+}
+
+# iam can create service account in the project
+resource "google_project_iam_binding" "create_sa" {
+	project = var.iam_project
+	role    = "roles/iam.serviceAccountAdmin"
+
+	members = [
+		"serviceAccount:${var.iam_sa}"
+	]
+}
+
+# google_folder_iam_binding for the role roles/resourcemanager.projectIamAdmin on the root folder of the course
+resource "google_folder_iam_binding" "assign_iam_policies" {
+	folder = var.root_folder
+	role   = "roles/resourcemanager.projectIamAdmin"
+
+	members = [
+		"serviceAccount:${var.iam_sa}"
+	]
+}
+
+# place the role: roles/serviceusage.serviceUsageConsumer on the billing_project
+resource "google_project_iam_member" "billing_project_service_usage" {
+	project = var.billing_project
+	role    = "roles/serviceusage.serviceUsageConsumer"
+	member = "serviceAccount:${var.iam_sa}"
+}
+
+# allow the admin group to impersonate the var.iam_sa
+resource "google_service_account_iam_binding" "impersonate_iam_sa" {
+	service_account_id = var.iam_sa_name
+	role               = "roles/iam.serviceAccountTokenCreator"
+	members = [
+		"group:${var.admin_group}"
+	]
+}

--- a/iac/gcp/tofu/iam/permissions/iam/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/permissions/iam/terragrunt.hcl
@@ -1,0 +1,43 @@
+/**
+ * This will create the permissions and roles that we give the iam service account
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+locals {
+  billing_vars = yamldecode(file(find_in_parent_folders("billing_vars.yaml")))
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "iam_project" {
+  config_path = "../../project"
+}
+
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
+dependency "root_folder" {
+  config_path = "../../../common/folders/root"
+}
+
+dependency "admin_group" {
+  config_path = "../../groups/admin"
+}
+
+terraform {
+  source = "./main.tf"
+}
+
+inputs = {
+  iam_project     = dependency.iam_project.outputs.project_id
+  iam_sa          = dependency.iam_sa.outputs.email
+  iam_sa_name     = dependency.iam_sa.outputs.service_account.name
+  root_folder     = dependency.root_folder.outputs.id
+  billing_project = local.billing_vars.billing_project
+  admin_group     = dependency.admin_group.outputs.id
+}

--- a/iac/gcp/tofu/iam/permissions/terragrunt/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/permissions/terragrunt/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version = "6.30.0"
+  hashes = [
+    "h1:vCUdTd378bnUIfiYvpPD8llQvPtQauadWKhnovSWMIE=",
+    "zh:0c79f7803f98651a5e22ba68f49623e6efddd603a6b7110d9d7b4955155a8eaf",
+    "zh:0fa4896cf880392b3b422b3151d237858aefc7f887710e955489691267c4c055",
+    "zh:1de84a8c628ec78b33058deb033d3ae77a4f5f67dfe3182f946a5c1bfeabd63d",
+    "zh:464fab03cdcfd9670810399f7307f6067281b3b5bf03e0a54a688fbc575adc66",
+    "zh:79425da1372e470b91c12ba326a530cf9d84221649ab8fb0ddeaddaf3208d6f6",
+    "zh:a26af9b468cdb9b3361bc2f575b185dde27deef8a2993c7667b645c21b77cc27",
+    "zh:c207fc074e9ed9c15e35efa0ecd3229d73e97685b386e8391b846bc0e59c85b2",
+    "zh:c3306fb116bcb47b0bbb659c84144a4a06fe5478c4d3cdf620d5dd027d603b89",
+    "zh:d63ada43c39cbd121ec97de121264fb422f964ac828c5c58b7581b8e7d4ea11b",
+    "zh:ecd61ad75f39be3fdc873a5b47ce65176ab046a5e08cf9cf7e0ed6d508f065f5",
+  ]
+}

--- a/iac/gcp/tofu/iam/permissions/terragrunt/main.tf
+++ b/iac/gcp/tofu/iam/permissions/terragrunt/main.tf
@@ -1,0 +1,16 @@
+/**
+ * This will provide the proper permission for terragrunt group to access terragrunt state bucket
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+variable "terragrunt_group" {
+	type = string
+}
+
+resource "google_storage_bucket_iam_member" "stoage_terragrunt_state" {
+	bucket = "academeez-k8s-flux-terragrunt-state"
+	role   = "roles/storage.admin"
+	member = "group:${var.terragrunt_group}"
+}

--- a/iac/gcp/tofu/iam/permissions/terragrunt/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/permissions/terragrunt/terragrunt.hcl
@@ -1,0 +1,19 @@
+/**
+ * Provide the needed roles for terragrunt group to access the terragrunt state bucket
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+dependency "admin_group" {
+  config_path = "../../groups/terragrunt"
+}
+
+terraform {
+  source = "./main.tf"
+}
+
+inputs = {
+  terragrunt_group = dependency.admin_group.outputs.id
+}
+

--- a/iac/gcp/tofu/iam/project/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/project/.terraform.lock.hcl
@@ -1,0 +1,92 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = ">= 3.43.0, >= 4.28.0, >= 5.41.0, < 7.0.0"
+  hashes = [
+    "h1:pMSQxf9MRGrylCl5IbbzoiN1g2hQMIS2LbCZ89nc/Ss=",
+    "zh:22c34039642fa56b912e89451f5c44e574813d67ab0759fe36d5d3fa2ca5cdc6",
+    "zh:5064ba937b539ba89738ba5a7e8355d12feaf68584f901d7d55ffbd64183ba4f",
+    "zh:6350440669d41a3b98d877a65b55176cf93e2cc86c15a5904775587546874013",
+    "zh:63f61dbbe72fd1bf221e8b84ed5fda5afd958ff50267f804a6648deb3172eba0",
+    "zh:7e657c3a802febe7299cee481613f80b6acfc2d19a3957306350f03c4782966a",
+    "zh:8ebabf9f3a6f7b29b3cf7d63f69d5576f3bac6e1d5187d52093bece12a282c68",
+    "zh:b2126150d7d6099de4220b12a704f7bda6eb8e0dc95d1e78cfdb12594a5603fa",
+    "zh:b5154becbdb228b55c811376cf1bd023e5a62dc5b0e075d4e17ca565bb1cf9b5",
+    "zh:e3985b7fe814b87bfc36d743320762d314798ada47c7d91f7be7eb95f14ce59f",
+    "zh:f64bbdf8f0b6ff3d5696cfc2e1675d3b65dc7cc821cc83f1e584f5e0e34d1749",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.29.0"
+  constraints = ">= 3.43.0, >= 4.11.0, >= 5.41.0, < 7.0.0"
+  hashes = [
+    "h1:Vw5+HajwxG2Yu58CDnsZ1zAm2d3j9CsbB7ICK+yA9TY=",
+    "zh:0f3070ce2eaafb7d3b6c479552310aa9c255e496a8dc9662bc0743160800d955",
+    "zh:33831afc143e900ec1d3c8910cbccb1fb30a059d41f3c925544adb7ef1125b9b",
+    "zh:546381b757a39ae1f5a7c5f2df18b465bb5d24673e1116013647960c284dedcb",
+    "zh:68b34f5d885e016478229fc8aa781b4803be43d5a28ddb9f786e068b3281203c",
+    "zh:6ee2bb59ad57bdbd23188fb850a18b5154b142e2423050349a020908d4f04d76",
+    "zh:779cb8f26f8a6b273fb0cc9be1177cd2d2bd7198ccbcac2b221a686c6eb80c61",
+    "zh:abfd416b0438f2fa5dfba5c48756c752b10f44badb0803031011eb508fa69a8d",
+    "zh:b2d9c637400b63efdb308d8d3ab9c156ab3ccdfdd698dbdb9b816c955e5937f1",
+    "zh:bca558543f53ea841319892606258e9834144328d551feec039b83fe8a109be0",
+    "zh:c3a515a0ede9224606ad851106ecd21a7ec503a925abd2b0ddd8d60abb4325a5",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:nNa5j1vTtxcpdC2i61O2tRkZjdkBNsxzYXYIx0VNsjc=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.7.1"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:HxqzkbeZlX7e/UfK6DA6SBYmd1+mURGRsRQHimwrpEM=",
+    "zh:1011387a5127d46e2bf0bd5124a8469506272b2110613d9eb80d178f94bd67a9",
+    "zh:28785c36d6dc331d49e8bf6a30d4ba21ae4378f5d98c43c0aeb42f51efb2e42f",
+    "zh:50fc0e52f0255950404681455420344a16263f91622bd481954606e6e3be9eb2",
+    "zh:563f22c53f40e41cfffdcfac32a9292292c10582183c3f1dd85770cf806bfce9",
+    "zh:586a5615898d369374d4bd7d70bc013cffe7553d3e14638f169a3f745665fee1",
+    "zh:6275f6e5697993048ac088715484a9a5e919682651e098a5ac31e567216bf102",
+    "zh:95a44bb3f012da1e036936d60df2d08f5942a96cb912fc23432d2ee050857527",
+    "zh:a5fe6b0e586645a88d98738739fec40fd7ad83dbc63fe66ff6327aee2dc07f11",
+    "zh:ea57886899b6baf466f3ff978f4482d2fd7fa049c42509cc819431375cddd5bd",
+    "zh:f021cfbe23bdb32738f170c1ae736ffb769a2fa3dcafd0f9906155c2e21377e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.13.0"
+  constraints = ">= 0.5.0"
+  hashes = [
+    "h1:IcKqYnr19ac05EeXPGD+wqWSZhOUXnuekZXqXJqJcaY=",
+    "zh:0e0a5f820793f13d8553742fac6c234f76e65bd095703a81f8f9cad38361d6c6",
+    "zh:11f2d5b5076d17814986886164bd4a4ce6448129baa529c21f658e949687f06f",
+    "zh:1a59c8d7da0c8155a86dffb1716bb5f2884b221a13167d5e7bcffb2ac192ba3f",
+    "zh:1e7abd01ef573294c0f2f1e2b30190c05a98afb7815d7a309fc10193bff4b4dd",
+    "zh:3ca53edfae9adffe1ee9c040e83b076fde89d73e7b2e6dc2de19d408e3f52a40",
+    "zh:5beb2cd0abe5376ff5e76d4f93d20c4740b333c1abc5ca72083e1cc85ffb29dd",
+    "zh:a775d153ba932834401eb1d9151f462c1e49d47494152d282d3e6981b3e591c0",
+    "zh:aac6802f60bf708172f09ead7a13177ab6a47f5a3eca458e935f422ed409f4a6",
+    "zh:d4e5ad0041d752b94317093e8063e6b766982f647cfe3cc1a3f4a10930383357",
+    "zh:fef228471c7223a558a1b6054ec7e8837526dc9787ba9da5dc6fbfa1c762cd1b",
+  ]
+}

--- a/iac/gcp/tofu/iam/project/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/project/terragrunt.hcl
@@ -1,0 +1,24 @@
+/**
+ * this will create the iam project under the iam folder
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "project" {
+  path = "${dirname(find_in_parent_folders())}/_env/project.hcl"
+}
+
+# since the project will be under the shared folder we will grab it using the dependency block
+dependency "iam_folder" {
+  config_path = "../folder"
+}
+
+inputs = {
+  folder_id = dependency.iam_folder.outputs.id
+  name      = "academeez-k8s-flux-iam"
+}

--- a/iac/gcp/tofu/iam/service-accounts/iam/.terraform.lock.hcl
+++ b/iac/gcp/tofu/iam/service-accounts/iam/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.29.0"
+  constraints = ">= 3.53.0, < 7.0.0"
+  hashes = [
+    "h1:pMSQxf9MRGrylCl5IbbzoiN1g2hQMIS2LbCZ89nc/Ss=",
+    "zh:22c34039642fa56b912e89451f5c44e574813d67ab0759fe36d5d3fa2ca5cdc6",
+    "zh:5064ba937b539ba89738ba5a7e8355d12feaf68584f901d7d55ffbd64183ba4f",
+    "zh:6350440669d41a3b98d877a65b55176cf93e2cc86c15a5904775587546874013",
+    "zh:63f61dbbe72fd1bf221e8b84ed5fda5afd958ff50267f804a6648deb3172eba0",
+    "zh:7e657c3a802febe7299cee481613f80b6acfc2d19a3957306350f03c4782966a",
+    "zh:8ebabf9f3a6f7b29b3cf7d63f69d5576f3bac6e1d5187d52093bece12a282c68",
+    "zh:b2126150d7d6099de4220b12a704f7bda6eb8e0dc95d1e78cfdb12594a5603fa",
+    "zh:b5154becbdb228b55c811376cf1bd023e5a62dc5b0e075d4e17ca565bb1cf9b5",
+    "zh:e3985b7fe814b87bfc36d743320762d314798ada47c7d91f7be7eb95f14ce59f",
+    "zh:f64bbdf8f0b6ff3d5696cfc2e1675d3b65dc7cc821cc83f1e584f5e0e34d1749",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version = "6.29.0"
+  hashes = [
+    "h1:Vw5+HajwxG2Yu58CDnsZ1zAm2d3j9CsbB7ICK+yA9TY=",
+    "zh:0f3070ce2eaafb7d3b6c479552310aa9c255e496a8dc9662bc0743160800d955",
+    "zh:33831afc143e900ec1d3c8910cbccb1fb30a059d41f3c925544adb7ef1125b9b",
+    "zh:546381b757a39ae1f5a7c5f2df18b465bb5d24673e1116013647960c284dedcb",
+    "zh:68b34f5d885e016478229fc8aa781b4803be43d5a28ddb9f786e068b3281203c",
+    "zh:6ee2bb59ad57bdbd23188fb850a18b5154b142e2423050349a020908d4f04d76",
+    "zh:779cb8f26f8a6b273fb0cc9be1177cd2d2bd7198ccbcac2b221a686c6eb80c61",
+    "zh:abfd416b0438f2fa5dfba5c48756c752b10f44badb0803031011eb508fa69a8d",
+    "zh:b2d9c637400b63efdb308d8d3ab9c156ab3ccdfdd698dbdb9b816c955e5937f1",
+    "zh:bca558543f53ea841319892606258e9834144328d551feec039b83fe8a109be0",
+    "zh:c3a515a0ede9224606ad851106ecd21a7ec503a925abd2b0ddd8d60abb4325a5",
+  ]
+}

--- a/iac/gcp/tofu/iam/service-accounts/iam/terragrunt.hcl
+++ b/iac/gcp/tofu/iam/service-accounts/iam/terragrunt.hcl
@@ -1,0 +1,26 @@
+/**
+ * this will create the iam service account
+ * This service account is in charge of creating the groups and service accounts, and permissions of those groups and service accounts
+ *
+ * Created April 18th, 2025
+ * @ywarezk
+ */
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+include "iam_sa" {
+  path = "${dirname(find_in_parent_folders())}/_env/service-account.hcl"
+}
+
+
+# iam project
+dependency "iam_project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  names      = ["iam"]
+  project_id = dependency.iam_project.outputs.project_id
+}

--- a/iac/gcp/tofu/terragrunt.hcl
+++ b/iac/gcp/tofu/terragrunt.hcl
@@ -12,6 +12,7 @@ locals {
   region_vars     = yamldecode(file(find_in_parent_folders("region_vars.yaml")))
   billing_vars    = yamldecode(file(find_in_parent_folders("billing_vars.yaml")))
   common_vars     = yamldecode(file(find_in_parent_folders("common_vars.yaml")))
+  iam             = try(yamldecode(file(find_in_parent_folders("iam.yaml"))), { "email" : "" })
   region          = local.region_vars.region
   billing_project = local.billing_vars.billing_project
   common_project  = local.common_vars.common_project
@@ -37,11 +38,50 @@ generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite"
   contents  = <<EOF
+%{if length(local.iam.email) > 0}
+# impersonate the service account
+provider "google" {
+  alias = "impersonation"
+}
+
+data "google_service_account_access_token" "default" {
+  provider               = google.impersonation
+  target_service_account = "${local.iam.email}"
+  scopes                 = ["userinfo-email", "cloud-platform"]
+  lifetime               = "3600s"
+}
+
+provider "google" {
+  region  = "${local.region}"
+  billing_project = "${local.billing_project}"
+  user_project_override = true
+  access_token = data.google_service_account_access_token.default.access_token
+}
+
+provider "google-beta" {
+  region  = "${local.region}"
+  billing_project = "${local.billing_project}"
+  user_project_override = true
+  access_token = data.google_service_account_access_token.default.access_token
+}
+
+%{else}
+# authenticate as a user for fallback
 provider "google" {	
 	region  = "${local.region}"
 	billing_project = "${local.billing_project}"
 	user_project_override = true
 }
+
+provider "google-beta" {
+  region  = "${local.region}"
+  billing_project = "${local.billing_project}"
+  user_project_override = true
+}
+%{endif}
+
+
+
 EOF
 }
  


### PR DESCRIPTION
Inside our `iac` project created the folder `iam`.  
The `iam` section will contain a project that will hold the groups definitions, service accounts for creating cloud resources, and roles and permissions.

We added a login in the root `terragrunt.hcl` to try and find the nearest `iam.yaml` and using it for impersonation