### PR TITLE
refactor(iac): make project catalog unit generic and reusable

### DIFF
--- a/iac/catalog/units/project/README.md
+++ b/iac/catalog/units/project/README.md
@@ -1,0 +1,125 @@
+<!-- Frontmatter
+name: GCP Project
+description: Create a Google Cloud project with project-factory best practices.
+tags:
+  - unit
+  - gcp
+  - google
+  - project
+-->
+
+# GCP Project
+
+Creates a Google Cloud project using the [terraform-google-modules/project-factory/google](https://registry.terraform.io/modules/terraform-google-modules/project-factory/google) module (v18.3.0).
+
+This is a **Unit** component. It provisions a project, attaches billing, enables APIs, and applies opinionated defaults from the upstream module.
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place and generates a `terragrunt.values.hcl` for any `values.*` references collected by the form.
+
+After scaffolding, wire the unit into your live repository and supply org- or environment-specific configuration there.
+
+## Consumption
+
+Include this unit from your live repository and supply module inputs in your `terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+include "project" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/project?ref=<version>"
+}
+
+dependency "parent_folder" {
+  config_path = "../folders/shared"
+}
+
+inputs = {
+  folder_id         = dependency.parent_folder.outputs.id
+  name              = "my-project"
+  org_id            = include.root.locals.org_id
+  billing_account   = include.root.locals.billing_account
+  random_project_id = true
+}
+```
+
+Org- and billing-specific values belong in the **live** repository (`root.hcl`), not in the catalog.
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Display name for the project. |
+| `billing_account` | `string` | Billing account ID to attach to the project. |
+
+You must also set **either** `folder_id` (project under a folder) **or** `org_id` (project under an organization). In practice, most live configs pass both when the folder lives under an org.
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `folder_id` | `string` | `""` | Folder ID to host the project. |
+| `org_id` | `string` | `null` | Organization ID (often supplied from live `root.hcl`). |
+| `random_project_id` | `bool` | `false` | Append a random suffix to the project ID for global uniqueness. |
+| `project_id` | `string` | `""` | Explicit project ID; if unset, derived from `name`. |
+| `activate_apis` | `list(string)` | `["compute.googleapis.com"]` | APIs to enable on the project. |
+| `budget_amount` | `number` | `null` | Budget alert amount; omit to skip budget creation. |
+| `labels` | `map(string)` | `{}` | Labels to apply to the project. |
+| `deletion_policy` | `string` | `"PREVENT"` | `DELETE` or `PREVENT` to control accidental project deletion. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/project-factory/google/latest?tab=inputs) for the full list.
+
+## Examples
+
+### Project under a folder
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "shared_folder" {
+  config_path = "../folders/shared"
+}
+
+inputs = {
+  folder_id         = dependency.shared_folder.outputs.id
+  name              = "platform-common"
+  org_id            = include.root.locals.org_id
+  billing_account   = include.root.locals.billing_account
+  random_project_id = true
+}
+```
+
+### Project with a budget alert
+
+Set `budget_amount` explicitly in live when you want billing alerts — the catalog does not impose a default:
+
+```hcl
+inputs = {
+  folder_id         = dependency.parent_folder.outputs.id
+  name              = "platform-dev"
+  org_id            = include.root.locals.org_id
+  billing_account   = include.root.locals.billing_account
+  random_project_id = true
+  budget_amount     = 50
+}
+```
+
+## Outputs
+
+Common outputs from this module:
+
+| Output | Description |
+|--------|-------------|
+| `project_id` | The created project ID. |
+| `project_number` | The project number. |
+| `project_name` | The project name. |
+| `service_account_email` | Default project service account email (if created). |
+
+See the [module outputs](https://registry.terraform.io/modules/terraform-google-modules/project-factory/google/latest?tab=outputs) for the full list.

--- a/iac/catalog/units/project/terragrunt.hcl
+++ b/iac/catalog/units/project/terragrunt.hcl
@@ -1,22 +1,10 @@
 /**
- * terragrunt function to create a project
+ * Google Cloud project unit.
  *
- * Created December 14th, 2024
- * @author ywarezk
+ * Wraps terraform-google-modules/project-factory/google.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
  */
 
-locals {
-  org_id          = yamldecode(file(find_in_parent_folders("common_vars.yaml"))).org_id
-  billing_account = yamldecode(file(find_in_parent_folders("billing_vars.yaml"))).billing_account
-}
-
 terraform {
-  source = "tfr:///terraform-google-modules/project-factory/google?version=17.1.0"
-}
-
-inputs = {
-  random_project_id = true
-  org_id            = local.org_id
-  billing_account   = local.billing_account
-  budget_amount     = 20
+  source = "tfr:///terraform-google-modules/project-factory/google?version=18.3.0"
 }

--- a/iac/live/common/project/terragrunt.hcl
+++ b/iac/live/common/project/terragrunt.hcl
@@ -6,19 +6,23 @@
  */
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
 }
 
 include "project" {
   path = "${get_repo_root()}/iac/catalog/units/project/terragrunt.hcl"
 }
 
-# since the project will be under the shared folder we will grab it using the dependency block
 dependency "shared_folder" {
   config_path = "../folders/shared"
 }
 
 inputs = {
-  folder_id = dependency.shared_folder.outputs.id
-  name      = "academeez-k8s-flux-common"
+  folder_id         = dependency.shared_folder.outputs.id
+  name              = "academeez-k8s-flux-common"
+  org_id            = include.root.locals.org_id
+  billing_account   = include.root.locals.billing_account
+  random_project_id = true
+  budget_amount     = 20
 }

--- a/iac/live/iam/project/terragrunt.hcl
+++ b/iac/live/iam/project/terragrunt.hcl
@@ -6,19 +6,23 @@
  */
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
 }
 
 include "project" {
   path = "${get_repo_root()}/iac/catalog/units/project/terragrunt.hcl"
 }
 
-# since the project will be under the shared folder we will grab it using the dependency block
 dependency "iam_folder" {
   config_path = "../folder"
 }
 
 inputs = {
-  folder_id = dependency.iam_folder.outputs.id
-  name      = "academeez-k8s-flux-iam"
+  folder_id         = dependency.iam_folder.outputs.id
+  name              = "academeez-k8s-flux-iam"
+  org_id            = include.root.locals.org_id
+  billing_account   = include.root.locals.billing_account
+  random_project_id = true
+  budget_amount     = 20
 }


### PR DESCRIPTION
## Summary

- Refactors the **GCP Project** catalog unit into a thin, reusable wrapper around `terraform-google-modules/project-factory/google` (v18.3.0)
- Removes org- and billing-specific logic from the catalog (`common_vars.yaml`, `billing_vars.yaml` lookups and hardcoded defaults)
- Moves project-specific configuration to live configs (`common/project`, `iam/project`) using `include.root.locals` from `root.hcl`
- Adds `iac/catalog/units/project/README.md` with Terragrunt catalog front-matter, required inputs, and consumption examples

Follows the same pattern introduced for the folder catalog unit in #18.

## Changes

### Catalog (`iac/catalog/units/project/`)

| Before | After |
|--------|-------|
| Loaded `org_id` and `billing_account` from YAML via `find_in_parent_folders` | Thin unit — only pins the Terraform module source |
| Hardcoded `random_project_id = true` and `budget_amount = 20` | No defaults — consumers pass inputs explicitly |
| project-factory **v17.1.0** | project-factory **v18.3.0** |

### Live (`iac/live/`)

- `common/project/terragrunt.hcl` and `iam/project/terragrunt.hcl` now use `expose = true` on the root include
- Pass `org_id`, `billing_account`, `random_project_id`, and `budget_amount` via `include.root.locals` and live-specific `inputs`
- Preserves existing behavior for this repository (`budget_amount = 20`, `random_project_id = true`)

## Consumption (external)

```hcl
include "root" {
  path   = find_in_parent_folders("root.hcl")
  expose = true
}

include "project" {
  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/project?ref=<version>"
}

inputs = {
  folder_id         = dependency.parent_folder.outputs.id
  name              = "my-project"
  org_id            = include.root.locals.org_id
  billing_account   = include.root.locals.billing_account
  random_project_id = true
}
```

## Test plan

- [ ] `terragrunt hcl validate` in `iac/live/common/project`
- [ ] `terragrunt hcl validate` in `iac/live/iam/project`
- [ ] `terragrunt plan` on common and IAM projects (no unexpected changes beyond module version bump)
- [ ] Verify project unit appears in `terragrunt catalog` under `iac/catalog`
