### PR TITLE
refactor(iac): make service account catalog unit generic and reusable

### DIFF
--- a/iac/catalog/units/service-account/README.md
+++ b/iac/catalog/units/service-account/README.md
@@ -1,0 +1,110 @@
+<!-- Frontmatter
+name: GCP Service Account
+description: Create Google Cloud service accounts in a project.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - service-account
+-->
+
+# GCP Service Account
+
+Creates one or more service accounts in a Google Cloud project.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/service-accounts/google](https://registry.terraform.io/modules/terraform-google-modules/service-accounts/google) module (v4.7.0).
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place and generates a `terragrunt.values.hcl` for any `values.*` references collected by the form.
+
+After scaffolding, wire the unit into your live repository and supply project-specific configuration there.
+
+## Consumption
+
+Include this unit from your live repository and supply module inputs in your `terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "service_account" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/service-account?ref=<version>"
+}
+
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id = dependency.project.outputs.project_id
+  names      = ["my-sa"]
+  prefix     = "my-org"
+}
+```
+
+Project-specific values (`project_id`, `names`, `prefix`) belong in the **live** repository, not in the catalog.
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `project_id` | `string` | The GCP project ID where service accounts are created. |
+| `names` | `list(string)` | Service account names (short names, not email addresses). |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prefix` | `string` | `""` | Prefix prepended to service account IDs for uniqueness across projects. |
+| `description` | `string` | `""` | Description applied to all created service accounts. |
+| `display_name` | `string` | `""` | Display name applied to all created service accounts. |
+| `project_roles` | `list(string)` | `[]` | Project-level IAM roles to grant to each service account. |
+| `generate_keys` | `bool` | `false` | Whether to generate JSON keys for the service accounts. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/service-accounts/google/latest?tab=inputs) for the full list.
+
+## Examples
+
+### Service account in a project
+
+```hcl
+dependency "iam_project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id = dependency.iam_project.outputs.project_id
+  names      = ["automation"]
+  prefix     = "platform"
+}
+```
+
+### Service account with project roles
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id    = dependency.project.outputs.project_id
+  names         = ["deployer"]
+  prefix        = "my-org"
+  project_roles = ["roles/storage.objectViewer"]
+}
+```
+
+## Outputs
+
+Common outputs from this module:
+
+| Output | Description |
+|--------|-------------|
+| `email` | Service account email address. |
+| `iam_email` | Map of service account name to IAM-style email (`serviceAccount:...`). |
+| `service_account` | Map of service account name to resource attributes. |
+
+See the [module outputs](https://registry.terraform.io/modules/terraform-google-modules/service-accounts/google/latest?tab=outputs) for the full list.

--- a/iac/catalog/units/service-account/terragrunt.hcl
+++ b/iac/catalog/units/service-account/terragrunt.hcl
@@ -1,14 +1,10 @@
 /**
- * terragrunt function to create a service account
+ * Google Cloud service account unit.
  *
- * Created April 18th, 2025
- * @author: ywarezk 
+ * Wraps terraform-google-modules/service-accounts/google.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
  */
 
 terraform {
-  source = "tfr:///terraform-google-modules/service-accounts/google?version=4.5.3"
-}
-
-inputs = {
-  prefix = "az-k8s"
+  source = "tfr:///terraform-google-modules/service-accounts/google?version=4.7.0"
 }

--- a/iac/live/iam/service-accounts/devops/terragrunt.hcl
+++ b/iac/live/iam/service-accounts/devops/terragrunt.hcl
@@ -23,4 +23,5 @@ dependency "iam_project" {
 inputs = {
   names      = ["devops"]
   project_id = dependency.iam_project.outputs.project_id
+  prefix     = "az-k8s"
 }

--- a/iac/live/iam/service-accounts/iam/terragrunt.hcl
+++ b/iac/live/iam/service-accounts/iam/terragrunt.hcl
@@ -23,4 +23,5 @@ dependency "iam_project" {
 inputs = {
   names      = ["iam"]
   project_id = dependency.iam_project.outputs.project_id
+  prefix     = "az-k8s"
 }


### PR DESCRIPTION
## Summary

- Refactors the **GCP Service Account** catalog unit into a thin, reusable wrapper around `terraform-google-modules/service-accounts/google` (v4.7.0)
- Removes the repo-specific `prefix = "az-k8s"` default from the catalog
- Moves `prefix` to live IAM service account configs to preserve existing account IDs
- Adds `iac/catalog/units/service-account/README.md` with Terragrunt catalog front-matter, required inputs, and consumption examples

Follows the same pattern introduced for the folder (#18) and project (#19) catalog units.

## Changes

### Catalog (`iac/catalog/units/service-account/`)

| Before | After |
|--------|-------|
| Hardcoded `prefix = "az-k8s"` in catalog `inputs` | Thin unit — only pins the Terraform module source |
| service-accounts module **v4.5.3** | service-accounts module **v4.7.0** |

### Live (`iac/live/iam/service-accounts/`)

| File | Change |
|------|--------|
| `devops/terragrunt.hcl` | Added `prefix = "az-k8s"` to `inputs` |
| `iam/terragrunt.hcl` | Added `prefix = "az-k8s"` to `inputs` |

These are the **only** live configs that include `iac/catalog/units/service-account`. Other IAM configs reference the created service accounts via `dependency` blocks or use the separate **`iac/catalog/units/iam/service-account`** unit for IAM role bindings (unchanged).

## Infrastructure impact

Merged Terraform inputs are unchanged for this repository:

- `prefix = "az-k8s"`
- `names = ["devops"]` / `["iam"]`
- `project_id` from `dependency.iam_project.outputs.project_id`

Account emails (e.g. `az-k8s-devops@...`) should remain the same. The module version bump (4.5.3 → 4.7.0) may still produce plan diffs — verify with `terragrunt plan`.

## Consumption (external)

```hcl
include "service_account" {
  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/service-account?ref=<version>"
}

dependency "project" {
  config_path = "../../project"
}

inputs = {
  project_id = dependency.project.outputs.project_id
  names      = ["my-sa"]
  prefix     = "my-org"
}
```

## Test plan

- [ ] `terragrunt hcl validate` in `iac/live/iam/service-accounts/devops`
- [ ] `terragrunt hcl validate` in `iac/live/iam/service-accounts/iam`
- [ ] `terragrunt plan` on devops and iam service accounts (no unexpected resource changes)
- [ ] Verify service account unit appears in `terragrunt catalog` under `iac/catalog`
