### PR TITLE
refactor(iac): make group catalog unit generic and reusable

### DIFF
--- a/iac/catalog/units/group/README.md
+++ b/iac/catalog/units/group/README.md
@@ -1,0 +1,130 @@
+<!-- Frontmatter
+name: GCP Group
+description: Create a Google Workspace group for Cloud IAM and organization management.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - group
+-->
+
+# GCP Group
+
+Creates a Google Workspace group using the [terraform-google-modules/group/google](https://registry.terraform.io/modules/terraform-google-modules/group/google) module (v0.8.0).
+
+This is a **Unit** component. It is typically used to manage group membership and ownership for GCP organization workflows.
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place and generates a `terragrunt.values.hcl` for any `values.*` references collected by the form.
+
+After scaffolding, wire the unit into your live repository and supply workspace- and org-specific configuration there.
+
+## Consumption
+
+Include this unit from your live repository and supply module inputs in your `terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+include "group" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/group?ref=v0.0.2"
+}
+
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
+inputs = {
+  customer_id  = include.root.locals.customer_id
+  owners       = [dependency.iam_sa.outputs.email]
+  id           = "my-group@example.com"
+  display_name = "My Group"
+  description  = "Example group"
+  members      = ["user@example.com"]
+}
+```
+
+`customer_id` belongs in the **live** repository (`root.hcl` from `common_vars.yaml`). Group identity (`id`, `members`, `owners`) is always live-specific.
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `customer_id` | `string` | Google Workspace customer ID. |
+| `id` | `string` | Group email address (e.g. `team@example.com`). |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `owners` | `list(string)` | `[]` | Group owners (user or service account emails). |
+| `managers` | `list(string)` | `[]` | Group managers. |
+| `members` | `list(string)` | `[]` | Group members. |
+| `display_name` | `string` | `""` | Display name for the group. |
+| `description` | `string` | `""` | Group description. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/group/google/latest?tab=inputs) for the full list.
+
+## Examples
+
+### Admin group owned by an IAM service account
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
+inputs = {
+  customer_id  = include.root.locals.customer_id
+  owners       = [dependency.iam_sa.outputs.email]
+  id           = "platform-admin@example.com"
+  display_name = "Platform Admin"
+  members      = ["ops@example.com"]
+}
+```
+
+### Group with another group as a member
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
+dependency "parent_group" {
+  config_path = "../admin"
+}
+
+inputs = {
+  customer_id  = include.root.locals.customer_id
+  owners       = [dependency.iam_sa.outputs.email]
+  id           = "platform-terragrunt@example.com"
+  display_name = "Terragrunt Operators"
+  members      = [dependency.parent_group.outputs.id]
+}
+```
+
+## Outputs
+
+Common outputs from this module:
+
+| Output | Description |
+|--------|-------------|
+| `id` | Group email address. |
+| `name` | Group resource name. |
+
+See the [module outputs](https://registry.terraform.io/modules/terraform-google-modules/group/google/latest?tab=outputs) for the full list.

--- a/iac/catalog/units/group/terragrunt.hcl
+++ b/iac/catalog/units/group/terragrunt.hcl
@@ -1,19 +1,10 @@
 /**
- * terragrunt function to create a group
+ * Google Cloud group unit.
  *
- * Created April 18th, 2025
- * @author: ywarezk 
+ * Wraps terraform-google-modules/group/google.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
  */
 
-locals {
-  customer_id = yamldecode(file(find_in_parent_folders("common_vars.yaml"))).customer_id
-}
-
 terraform {
-  source = "tfr:///terraform-google-modules/group/google?version=0.7.0"
-}
-
-inputs = {
-  customer_id = local.customer_id
-  owners      = ["az-k8s-iam@academeez-k8s-flux-iam-c55b.iam.gserviceaccount.com"]
+  source = "tfr:///terraform-google-modules/group/google?version=0.8.0"
 }

--- a/iac/live/iam/groups/admin/terragrunt.hcl
+++ b/iac/live/iam/groups/admin/terragrunt.hcl
@@ -1,15 +1,21 @@
 
 
-
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
 }
 
 include "group" {
   path = "${get_repo_root()}/iac/catalog/units/group/terragrunt.hcl"
 }
 
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
 inputs = {
+  customer_id  = include.root.locals.customer_id
+  owners       = [dependency.iam_sa.outputs.email]
   id           = "k8s-flux-admin@academeez.com"
   display_name = "k8s-flux-admin"
   description  = "k8s flux admin group"

--- a/iac/live/iam/groups/devops/terragrunt.hcl
+++ b/iac/live/iam/groups/devops/terragrunt.hcl
@@ -1,15 +1,21 @@
 
 
-
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
 }
 
 include "group" {
   path = "${get_repo_root()}/iac/catalog/units/group/terragrunt.hcl"
 }
 
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
 inputs = {
+  customer_id  = include.root.locals.customer_id
+  owners       = [dependency.iam_sa.outputs.email]
   id           = "k8s-flux-devops@academeez.com"
   display_name = "k8s-flux-devops"
   description  = "k8s flux devops group"

--- a/iac/live/iam/groups/terragrunt/terragrunt.hcl
+++ b/iac/live/iam/groups/terragrunt/terragrunt.hcl
@@ -1,8 +1,8 @@
 
 
-
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
 }
 
 include "group" {
@@ -13,7 +13,13 @@ dependency "admin_group" {
   config_path = "../admin"
 }
 
+dependency "iam_sa" {
+  config_path = "../../service-accounts/iam"
+}
+
 inputs = {
+  customer_id  = include.root.locals.customer_id
+  owners       = [dependency.iam_sa.outputs.email]
   id           = "k8s-flux-terragrunt@academeez.com"
   display_name = "k8s-flux-terragrunt"
   description  = "k8s flux terragrunt bucket"

--- a/iac/live/root.hcl
+++ b/iac/live/root.hcl
@@ -18,6 +18,7 @@ locals {
   billing_account = local.billing_vars.billing_account
   common_project  = local.common_vars.common_project
   org_id          = local.common_vars.org_id
+  customer_id     = local.common_vars.customer_id
 }
 
 # configure remote state in bucket


### PR DESCRIPTION
## Summary

- Refactors the **GCP Group** catalog unit into a thin, reusable wrapper around `terraform-google-modules/group/google` (v0.8.0)
- Removes `common_vars.yaml` lookup and hardcoded IAM service account owners from the catalog
- Exports `customer_id` in `root.hcl` and moves group-specific inputs to live configs
- Adds `iac/catalog/units/group/README.md` with Terragrunt catalog front-matter, required inputs, and consumption examples

Follows the same pattern introduced for the folder (#18), project (#19), and service account (#20) catalog units.

## Changes

### Catalog (`iac/catalog/units/group/`)

| Before | After |
|--------|-------|
| Loaded `customer_id` from `common_vars.yaml` via `find_in_parent_folders` | Thin unit — only pins the Terraform module source |
| Hardcoded `owners` to a specific IAM service account email | No defaults — consumers pass `owners` explicitly |
| group module **v0.7.0** | group module **v0.8.0** |

### Live (`iac/live/`)

| File | Change |
|------|--------|
| `root.hcl` | Export `customer_id` from `common_vars.yaml` |
| `iam/groups/admin/terragrunt.hcl` | `expose = true`, `customer_id` from `include.root.locals`, `owners` from IAM SA dependency |
| `iam/groups/devops/terragrunt.hcl` | Same as admin |
| `iam/groups/terragrunt/terragrunt.hcl` | Same pattern; still depends on `admin` group for `members` |

These are the **only** live configs that include `iac/catalog/units/group`.

## Infrastructure impact

Merged Terraform inputs should be equivalent for this repository:

| Input | Before | After |
|-------|--------|-------|
| `customer_id` | from `common_vars.yaml` (catalog) | `include.root.locals.customer_id` |
| `owners` | hardcoded IAM SA email | `dependency.iam_sa.outputs.email` |
| `id`, `display_name`, `description`, `members` | live (unchanged) | unchanged |

The module version bump (0.7.0 → 0.8.0) may still produce plan diffs — verify with `terragrunt plan`.

## Consumption (external)

```hcl
include "root" {
  path   = find_in_parent_folders("root.hcl")
  expose = true
}

include "group" {
  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/group?ref=<version>"
}

dependency "iam_sa" {
  config_path = "../../service-accounts/iam"
}

inputs = {
  customer_id  = include.root.locals.customer_id
  owners       = [dependency.iam_sa.outputs.email]
  id           = "my-group@example.com"
  display_name = "My Group"
  members      = ["user@example.com"]
}
```

## Test plan

- [ ] `terragrunt hcl validate` in `iac/live/iam/groups/admin`
- [ ] `terragrunt hcl validate` in `iac/live/iam/groups/devops`
- [ ] `terragrunt hcl validate` in `iac/live/iam/groups/terragrunt`
- [ ] `terragrunt plan` on admin, devops, and terragrunt groups (no unexpected resource changes)
- [ ] Verify group unit appears in `terragrunt catalog` under `iac/catalog`
