### PR TITLE
docs(iac): document IAM catalog units for reusable consumption

### DIFF
--- a/iac/catalog/units/iam/billing-account/README.md
+++ b/iac/catalog/units/iam/billing-account/README.md
@@ -1,0 +1,66 @@
+<!-- Frontmatter
+name: GCP Billing Account IAM
+description: Manage IAM role bindings on Google Cloud billing accounts.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - billing
+-->
+
+# GCP Billing Account IAM
+
+Manages IAM bindings on one or more Google Cloud billing accounts.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/iam/google//modules/billing_accounts_iam](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/billing_accounts_iam) submodule (v8.1.0).
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place.
+
+After scaffolding, wire the unit into your live repository and supply environment-specific configuration there.
+
+## Consumption
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+include "iam_billing_account" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/iam/billing-account?ref=v0.0.2"
+}
+
+dependency "iam_sa" {
+  config_path = "../../../service-accounts/iam"
+}
+
+inputs = {
+  billing_account_ids = [include.root.locals.billing_account]
+  mode                = "additive"
+  bindings = {
+    "roles/billing.admin" = [
+      "serviceAccount:${dependency.iam_sa.outputs.email}"
+    ]
+  }
+}
+```
+
+Billing account IDs belong in the **live** repository (`root.hcl` from `billing_vars.yaml`).
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `billing_account_ids` | `list(string)` | Billing account IDs to bind roles on. |
+| `bindings` | `map(list(string))` | Map of role → list of members. |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `string` | `"additive"` | `additive` merges bindings; `authoritative` replaces bindings for listed roles. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/billing_accounts_iam?tab=inputs) for the full list.

--- a/iac/catalog/units/iam/billing-account/terragrunt.hcl
+++ b/iac/catalog/units/iam/billing-account/terragrunt.hcl
@@ -1,3 +1,10 @@
+/**
+ * IAM bindings for Google Cloud billing accounts.
+ *
+ * Wraps terraform-google-modules/iam/google//modules/billing_accounts_iam.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
+ */
+
 terraform {
   source = "tfr:///terraform-google-modules/iam/google//modules/billing_accounts_iam?version=8.1.0"
 }

--- a/iac/catalog/units/iam/folder/README.md
+++ b/iac/catalog/units/iam/folder/README.md
@@ -1,0 +1,67 @@
+<!-- Frontmatter
+name: GCP Folder IAM
+description: Manage IAM role bindings on Google Cloud folders.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - folder
+-->
+
+# GCP Folder IAM
+
+Manages IAM bindings on one or more Google Cloud folders.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/iam/google//modules/folders_iam](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/folders_iam) submodule (v8.1.0).
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place.
+
+After scaffolding, wire the unit into your live repository and supply environment-specific configuration there.
+
+## Consumption
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "iam_folder" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/iam/folder?ref=v0.0.2"
+}
+
+dependency "folder" {
+  config_path = "../../../../common/folders/root"
+}
+
+dependency "iam_sa" {
+  config_path = "../../../service-accounts/iam"
+}
+
+inputs = {
+  folders = [dependency.folder.outputs.id]
+  mode    = "authoritative"
+  bindings = {
+    "roles/resourcemanager.folderViewer" = [
+      "serviceAccount:${dependency.iam_sa.outputs.email}"
+    ]
+  }
+}
+```
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `folders` | `list(string)` | Folder IDs or `folders/{id}` values to bind roles on. |
+| `bindings` | `map(list(string))` | Map of role → list of members (`user:`, `group:`, `serviceAccount:`). |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `string` | `"additive"` | `additive` merges bindings; `authoritative` replaces bindings for listed roles. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/folders_iam?tab=inputs) for the full list.

--- a/iac/catalog/units/iam/folder/terragrunt.hcl
+++ b/iac/catalog/units/iam/folder/terragrunt.hcl
@@ -1,3 +1,10 @@
+/**
+ * IAM bindings for Google Cloud folders.
+ *
+ * Wraps terraform-google-modules/iam/google//modules/folders_iam.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
+ */
+
 terraform {
   source = "tfr:///terraform-google-modules/iam/google//modules/folders_iam?version=8.1.0"
 }

--- a/iac/catalog/units/iam/project/README.md
+++ b/iac/catalog/units/iam/project/README.md
@@ -1,0 +1,64 @@
+<!-- Frontmatter
+name: GCP Project IAM
+description: Manage IAM role bindings on Google Cloud projects.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - project
+-->
+
+# GCP Project IAM
+
+Manages IAM bindings on one or more Google Cloud projects.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/iam/google//modules/projects_iam](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/projects_iam) submodule (v8.1.0).
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place.
+
+After scaffolding, wire the unit into your live repository and supply environment-specific configuration there.
+
+## Consumption
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+include "iam_project" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/iam/project?ref=v0.0.2"
+}
+
+dependency "iam_sa" {
+  config_path = "../../../service-accounts/iam"
+}
+
+inputs = {
+  projects = [include.root.locals.billing_project]
+  mode     = "additive"
+  bindings = {
+    "roles/serviceusage.serviceUsageConsumer" = [
+      "serviceAccount:${dependency.iam_sa.outputs.email}"
+    ]
+  }
+}
+```
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `projects` | `list(string)` | Project IDs to bind roles on. |
+| `bindings` | `map(list(string))` | Map of role → list of members. |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `string` | `"additive"` | `additive` merges bindings; `authoritative` replaces bindings for listed roles. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/projects_iam?tab=inputs) for the full list.

--- a/iac/catalog/units/iam/project/terragrunt.hcl
+++ b/iac/catalog/units/iam/project/terragrunt.hcl
@@ -1,3 +1,10 @@
+/**
+ * IAM bindings for Google Cloud projects.
+ *
+ * Wraps terraform-google-modules/iam/google//modules/projects_iam.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
+ */
+
 terraform {
   source = "tfr:///terraform-google-modules/iam/google//modules/projects_iam?version=8.1.0"
 }

--- a/iac/catalog/units/iam/service-account/README.md
+++ b/iac/catalog/units/iam/service-account/README.md
@@ -1,0 +1,75 @@
+<!-- Frontmatter
+name: GCP Service Account IAM
+description: Manage IAM role bindings on Google Cloud service accounts.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - service-account
+-->
+
+# GCP Service Account IAM
+
+Manages IAM bindings on service accounts within a project.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/iam/google//modules/service_accounts_iam](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/service_accounts_iam) submodule (v8.1.0).
+
+> **Note:** This unit grants IAM **on** service accounts. To **create** service accounts, use the [`service-account`](../../service-account/) catalog unit.
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place.
+
+After scaffolding, wire the unit into your live repository and supply environment-specific configuration there.
+
+## Consumption
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "iam_service_account" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/iam/service-account?ref=v0.0.2"
+}
+
+dependency "iam_sa" {
+  config_path = "../../../service-accounts/iam"
+}
+
+dependency "admin_group" {
+  config_path = "../../../groups/admin"
+}
+
+dependency "project" {
+  config_path = "../../../project"
+}
+
+inputs = {
+  service_accounts = [dependency.iam_sa.outputs.email]
+  project          = dependency.project.outputs.project_id
+  mode             = "authoritative"
+  bindings = {
+    "roles/iam.serviceAccountTokenCreator" = [
+      "group:${dependency.admin_group.outputs.id}"
+    ]
+  }
+}
+```
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `service_accounts` | `list(string)` | Service account emails to bind roles on. |
+| `project` | `string` | Project ID containing the service accounts. |
+| `bindings` | `map(list(string))` | Map of role → list of members. |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `string` | `"additive"` | `additive` merges bindings; `authoritative` replaces bindings for listed roles. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/service_accounts_iam?tab=inputs) for the full list.

--- a/iac/catalog/units/iam/service-account/terragrunt.hcl
+++ b/iac/catalog/units/iam/service-account/terragrunt.hcl
@@ -1,3 +1,10 @@
+/**
+ * IAM bindings for Google Cloud service accounts.
+ *
+ * Wraps terraform-google-modules/iam/google//modules/service_accounts_iam.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
+ */
+
 terraform {
   source = "tfr:///terraform-google-modules/iam/google//modules/service_accounts_iam?version=8.1.0"
 }

--- a/iac/catalog/units/iam/storage-bucket/README.md
+++ b/iac/catalog/units/iam/storage-bucket/README.md
@@ -1,0 +1,63 @@
+<!-- Frontmatter
+name: GCP Storage Bucket IAM
+description: Manage IAM role bindings on Google Cloud Storage buckets.
+tags:
+  - unit
+  - gcp
+  - google
+  - iam
+  - storage
+-->
+
+# GCP Storage Bucket IAM
+
+Manages IAM bindings on one or more Google Cloud Storage buckets.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/iam/google//modules/storage_buckets_iam](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/storage_buckets_iam) submodule (v8.1.0).
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place.
+
+After scaffolding, wire the unit into your live repository and supply environment-specific configuration there.
+
+## Consumption
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "iam_storage_bucket" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/catalog/units/iam/storage-bucket?ref=v0.0.2"
+}
+
+dependency "operators_group" {
+  config_path = "../../../groups/terragrunt"
+}
+
+inputs = {
+  storage_buckets = ["my-terragrunt-state-bucket"]
+  mode            = "additive"
+  bindings = {
+    "roles/storage.admin" = [
+      "group:${dependency.operators_group.outputs.id}"
+    ]
+  }
+}
+```
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `storage_buckets` | `list(string)` | Storage bucket names to bind roles on. |
+| `bindings` | `map(list(string))` | Map of role → list of members. |
+
+## Commonly used optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `string` | `"additive"` | `additive` merges bindings; `authoritative` replaces bindings for listed roles. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/iam/google/latest/submodules/storage_buckets_iam?tab=inputs) for the full list.

--- a/iac/catalog/units/iam/storage-bucket/terragrunt.hcl
+++ b/iac/catalog/units/iam/storage-bucket/terragrunt.hcl
@@ -1,3 +1,10 @@
+/**
+ * IAM bindings for Google Cloud Storage buckets.
+ *
+ * Wraps terraform-google-modules/iam/google//modules/storage_buckets_iam.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl.
+ */
+
 terraform {
   source = "tfr:///terraform-google-modules/iam/google//modules/storage_buckets_iam?version=8.1.0"
 }


### PR DESCRIPTION
## Summary

- Documents all five **IAM binding** catalog units under `iac/catalog/units/iam/`
- Adds Terragrunt catalog README front-matter (`name`, `description`, `tags`) for catalog TUI discovery
- Adds header comments to each unit's `terragrunt.hcl` for consistency with other catalog units

The IAM units were already generic thin wrappers (module source only, no repo-specific inputs). This PR is **documentation only** — no live config changes and no infrastructure impact.

## Units documented

| Unit | Submodule | Purpose |
|------|-----------|---------|
| `iam/folder` | `folders_iam` | IAM bindings on folders |
| `iam/project` | `projects_iam` | IAM bindings on projects |
| `iam/billing-account` | `billing_accounts_iam` | IAM bindings on billing accounts |
| `iam/service-account` | `service_accounts_iam` | IAM bindings **on** service accounts |
| `iam/storage-bucket` | `storage_buckets_iam` | IAM bindings on GCS buckets |

All units pin `terraform-google-modules/iam/google` submodule **v8.1.0**.

> **Note:** `iam/service-account` grants IAM on existing service accounts. To **create** service accounts, use the [`service-account`](../service-account/) catalog unit.

## Live usage (unchanged)

Nine live permission configs already consume these units and pass all inputs via `inputs` blocks — no updates required:

- `permissions/iam/root_folder`, `permissions/devops/root_folder`
- `permissions/iam/iam_project`, `permissions/iam/billing_project`, `permissions/devops/billing_project`
- `permissions/iam/billing_account`, `permissions/devops/billing_account`
- `permissions/iam/service-account`, `permissions/devops/service-account`
- `permissions/terragrunt/state-bucket`

## Test plan

- [ ] `terragrunt catalog` shows all five IAM units under `iac/catalog`
- [ ] README front-matter renders correctly in catalog TUI detail view
- [ ] Spot-check `terragrunt hcl validate` on one live consumer per unit type (optional — no live files changed)
