### PR TITLE
refactor(iac): add storage-bucket catalog unit

### DIFF
--- a/iac/gcp/catalog/units/storage-bucket/README.md
+++ b/iac/gcp/catalog/units/storage-bucket/README.md
@@ -99,7 +99,7 @@ Project-specific values (`project_id`, `names`, `prefix`, `location`) belong in 
 | `randomize_suffix` | `bool` | `false` | Adds an identical, but randomized 4-character suffix to all bucket names. |
 | `labels` | `map(string)` | `{}` | Labels to be attached to the buckets. |
 | `public_access_prevention` | `string` | `"inherited"` | Prevents public access to a bucket (`inherited` or `enforced`). |
-| `versioning` | `map(bool)` | `{}` | Map of lowercase unprefixed name => boolean. |
+| `versioning` | `map(bool)` | `{}` | Map of bucket name suffix => boolean. |
 | `autoclass` | `map(bool)` | `{}` | Map of bucket name suffix => enable Autoclass. |
 | `bucket_policy_only` | `map(bool)` | `{}` | Disable ad-hoc ACLs on specified buckets (defaults to `true` when set). |
 | `force_destroy` | `map(bool)` | `{}` | Map of bucket name suffix => allow Terraform to delete non-empty buckets. |

--- a/iac/gcp/catalog/units/storage-bucket/README.md
+++ b/iac/gcp/catalog/units/storage-bucket/README.md
@@ -1,0 +1,227 @@
+<!-- Frontmatter
+name: GCP Storage Bucket
+description: Create Google Cloud Storage buckets in a project.
+tags:
+  - unit
+  - gcp
+  - google
+  - storage
+  - bucket
+-->
+
+# GCP Storage Bucket
+
+Creates one or more Google Cloud Storage buckets in a project.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/cloud-storage/google](https://registry.terraform.io/modules/terraform-google-modules/cloud-storage/google) module (v12.3.0).
+
+> **Note:** This unit **creates** buckets. To manage IAM **on** existing buckets, use the [`iam/storage-bucket`](../iam/storage-bucket/) catalog unit.
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place and prompts for each `values.*` reference (press `x` on optional fields to keep the `try()` default). It writes a `terragrunt.values.hcl` with the answers you provide.
+
+| Value | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `project_id` | yes | — | Project ID where buckets will be created. |
+| `names` | yes | — | Bucket name suffixes (combined with `prefix` to form the full bucket name). |
+| `prefix` | no | `""` | Prefix used to generate globally unique bucket names. |
+| `location` | no | `"EU"` | Bucket location (region or multi-region). |
+| `storage_class` | no | `"STANDARD"` | Bucket storage class. |
+| `randomize_suffix` | no | `false` | Add a randomized 4-character suffix to all bucket names. |
+| `labels` | no | `{}` | Labels attached to all buckets. |
+| `public_access_prevention` | no | `"inherited"` | Public access prevention (`inherited` or `enforced`). |
+| `versioning` | no | `{}` | Map of bucket name suffix => enable versioning. |
+| `force_destroy` | no | `{}` | Map of bucket name suffix => allow force destroy. |
+| `bucket_policy_only` | no | `{}` | Map of bucket name suffix => uniform bucket-level access (defaults to `true` per bucket when set). |
+
+Set `project_id` and `names` together when scaffolding a real bucket.
+
+After scaffolding, wire the unit into your live repository and supply project-specific configuration there.
+
+In a stack `unit` block you only need to set the values you care about; optional keys use the `try()` defaults in the catalog unit. Required keys such as `project_id` and `names` can be omitted from `values` when you supply them via an `autoinclude` `inputs` block instead (see [catalog units README](../README.md)).
+
+## Consumption
+
+Include this unit from your live repository and supply module inputs in your `terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "storage_bucket" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/gcp/catalog/units/storage-bucket?ref=<version>"
+}
+
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id = dependency.project.outputs.project_id
+  names      = ["terragrunt-state"]
+  prefix     = "academeez-k8s-flux"
+  location   = "EU"
+  versioning = {
+    terragrunt-state = true
+  }
+}
+```
+
+Project-specific values (`project_id`, `names`, `prefix`, `location`) belong in the **live** repository, not in the catalog.
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `project_id` | `string` | Project ID where buckets will be created. |
+| `names` | `list(string)` | Bucket name suffixes. (Module default is `[]`; this unit expects at least one name when creating buckets.) |
+
+## Commonly set in live
+
+| Input | Notes |
+|-------|--------|
+| `prefix` | Often an org or environment slug for globally unique bucket names. |
+| `location` | Region or multi-region (e.g. `EU`, `US`, `europe-west1`). |
+| `versioning` | Enable versioning per bucket suffix (e.g. for state or backup buckets). |
+| `force_destroy` | Set to `true` for ephemeral or sandbox buckets. |
+| `public_access_prevention` | Use `enforced` for sensitive data. |
+| `labels` | Environment or team labels for cost allocation. |
+
+## Optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prefix` | `string` | `""` | Prefix used to generate the bucket name. |
+| `location` | `string` | `"EU"` | Bucket location. |
+| `storage_class` | `string` | `"STANDARD"` | Bucket storage class. |
+| `randomize_suffix` | `bool` | `false` | Adds an identical, but randomized 4-character suffix to all bucket names. |
+| `labels` | `map(string)` | `{}` | Labels to be attached to the buckets. |
+| `public_access_prevention` | `string` | `"inherited"` | Prevents public access to a bucket (`inherited` or `enforced`). |
+| `versioning` | `map(bool)` | `{}` | Map of lowercase unprefixed name => boolean. |
+| `autoclass` | `map(bool)` | `{}` | Map of bucket name suffix => enable Autoclass. |
+| `bucket_policy_only` | `map(bool)` | `{}` | Disable ad-hoc ACLs on specified buckets (defaults to `true` when set). |
+| `force_destroy` | `map(bool)` | `{}` | Map of bucket name suffix => allow Terraform to delete non-empty buckets. |
+| `default_event_based_hold` | `map(bool)` | `{}` | Enable event-based hold on new objects per bucket. |
+| `hierarchical_namespace` | `map(bool)` | `{}` | Enable hierarchical namespace per bucket. |
+| `encryption_key_names` | `map(string)` | `{}` | Map of bucket name suffix => KMS key name. |
+| `retention_policy` | `any` | `{}` | Map of retention policy values per bucket. |
+| `soft_delete_policy` | `map(any)` | `{}` | Soft delete policies per bucket. |
+| `logging` | `any` | `{}` | Access logging configuration per bucket. |
+| `website` | `object` | `{}` | Website configuration (`main_page_suffix`, `not_found_page`). |
+| `custom_placement_config` | `any` | `{}` | Custom dual-region placement config per bucket. |
+| `folders` | `map(list(string))` | `{}` | Map of bucket name suffix => list of top-level folder objects to create. |
+| `lifecycle_rules` | `set(object)` | `[]` | Lifecycle rules applied to all buckets. |
+| `bucket_lifecycle_rules` | `map(set(object))` | `{}` | Per-bucket lifecycle rules. |
+| `cors` | `list(object)` | `[]` | CORS configuration for buckets. |
+| `ip_filter` | `map(object)` | `{}` | IP filter configuration per bucket. |
+| `set_admin_roles` | `bool` | `false` | Grant `roles/storage.objectAdmin` to `admins` and `bucket_admins`. |
+| `admins` | `list(string)` | `[]` | IAM members granted object admin on all buckets. |
+| `bucket_admins` | `map(string)` | `{}` | Per-bucket object admins (comma-delimited IAM members). |
+| `set_creator_roles` | `bool` | `false` | Grant `roles/storage.objectCreator` to `creators` and `bucket_creators`. |
+| `creators` | `list(string)` | `[]` | IAM members granted object creator on all buckets. |
+| `bucket_creators` | `map(string)` | `{}` | Per-bucket object creators (comma-delimited IAM members). |
+| `set_viewer_roles` | `bool` | `false` | Grant `roles/storage.objectViewer` to `viewers` and `bucket_viewers`. |
+| `viewers` | `list(string)` | `[]` | IAM members granted object viewer on all buckets. |
+| `bucket_viewers` | `map(string)` | `{}` | Per-bucket object viewers (comma-delimited IAM members). |
+| `set_storage_admin_roles` | `bool` | `false` | Grant `roles/storage.admin` to `storage_admins` and `bucket_storage_admins`. |
+| `storage_admins` | `list(string)` | `[]` | IAM members granted storage admin on all buckets. |
+| `bucket_storage_admins` | `map(string)` | `{}` | Per-bucket storage admins (comma-delimited IAM members). |
+| `set_hmac_key_admin_roles` | `bool` | `false` | Grant `roles/storage.hmacKeyAdmin` to HMAC key admins. |
+| `hmac_key_admins` | `list(string)` | `[]` | IAM members granted HMAC key admin on all buckets. |
+| `bucket_hmac_key_admins` | `map(string)` | `{}` | Per-bucket HMAC key admins (comma-delimited IAM members). |
+| `set_hmac_access` | `bool` | `false` | Set S3-compatible access to GCS. |
+| `hmac_service_accounts` | `map(string)` | `{}` | HMAC service accounts to grant access to GCS. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/cloud-storage/google/12.3.0?tab=inputs) for full details.
+
+## Examples
+
+### Terragrunt state bucket
+
+```hcl
+dependency "iam_project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id = dependency.iam_project.outputs.project_id
+  names      = ["terragrunt-state"]
+  prefix     = "academeez-k8s-flux"
+  location   = "EU"
+  versioning = {
+    terragrunt-state = true
+  }
+  public_access_prevention = "enforced"
+}
+```
+
+### Bucket with IAM admins
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+dependency "operators_group" {
+  config_path = "../../../groups/terragrunt"
+}
+
+inputs = {
+  project_id      = dependency.project.outputs.project_id
+  names           = ["artifacts"]
+  prefix          = "my-org"
+  location        = "europe-west1"
+  set_admin_roles = true
+  admins = [
+    "group:${dependency.operators_group.outputs.id}"
+  ]
+}
+```
+
+### Multiple buckets with per-bucket settings
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id = dependency.project.outputs.project_id
+  names      = ["logs", "backups"]
+  prefix     = "platform-dev"
+  location   = "EU"
+  versioning = {
+    backups = true
+  }
+  lifecycle_rules = [
+    {
+      action = {
+        type = "Delete"
+      }
+      condition = {
+        age = 90
+      }
+    }
+  ]
+}
+```
+
+## Outputs
+
+Common outputs from this module:
+
+| Output | Description |
+|--------|-------------|
+| `names` | Map of bucket name suffix to full bucket name. |
+| `names_list` | List of full bucket names. |
+| `urls` | Map of bucket name suffix to bucket URL. |
+| `urls_list` | List of bucket URLs. |
+| `bucket` | Bucket resource (for single-bucket use). |
+| `name` | Full bucket name (for single-bucket use). |
+| `url` | Bucket URL (for single-bucket use). |
+| `buckets` | Bucket resources as a list. |
+| `buckets_map` | Bucket resources keyed by name suffix. |
+
+See the [module outputs](https://registry.terraform.io/modules/terraform-google-modules/cloud-storage/google/12.3.0?tab=outputs) for the full list.

--- a/iac/gcp/catalog/units/storage-bucket/terragrunt.hcl
+++ b/iac/gcp/catalog/units/storage-bucket/terragrunt.hcl
@@ -1,0 +1,62 @@
+/**
+ * Google Cloud Storage bucket unit.
+ *
+ * Wraps terraform-google-modules/cloud-storage/google.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl,
+ * or via `terragrunt.values.hcl` when scaffolding from the catalog (`values.*`).
+ */
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "tfr:///terraform-google-modules/cloud-storage/google?version=12.3.0"
+}
+
+inputs = merge(
+  {
+    prefix                   = try(values.prefix, "")
+    location                 = try(values.location, "EU")
+    storage_class            = try(values.storage_class, "STANDARD")
+    randomize_suffix         = try(values.randomize_suffix, false)
+    labels                   = try(values.labels, {})
+    public_access_prevention = try(values.public_access_prevention, "inherited")
+    versioning               = try(values.versioning, {})
+    autoclass                = try(values.autoclass, {})
+    bucket_policy_only       = try(values.bucket_policy_only, {})
+    force_destroy            = try(values.force_destroy, {})
+    default_event_based_hold = try(values.default_event_based_hold, {})
+    hierarchical_namespace   = try(values.hierarchical_namespace, {})
+    encryption_key_names     = try(values.encryption_key_names, {})
+    retention_policy         = try(values.retention_policy, {})
+    soft_delete_policy       = try(values.soft_delete_policy, {})
+    logging                  = try(values.logging, {})
+    website                  = try(values.website, {})
+    custom_placement_config  = try(values.custom_placement_config, {})
+    folders                  = try(values.folders, {})
+    lifecycle_rules          = try(values.lifecycle_rules, [])
+    bucket_lifecycle_rules   = try(values.bucket_lifecycle_rules, {})
+    cors                     = try(values.cors, [])
+    ip_filter                = try(values.ip_filter, {})
+    set_admin_roles          = try(values.set_admin_roles, false)
+    admins                   = try(values.admins, [])
+    bucket_admins            = try(values.bucket_admins, {})
+    set_creator_roles        = try(values.set_creator_roles, false)
+    creators                 = try(values.creators, [])
+    bucket_creators          = try(values.bucket_creators, {})
+    set_viewer_roles         = try(values.set_viewer_roles, false)
+    viewers                  = try(values.viewers, [])
+    bucket_viewers           = try(values.bucket_viewers, {})
+    set_storage_admin_roles  = try(values.set_storage_admin_roles, false)
+    storage_admins           = try(values.storage_admins, [])
+    bucket_storage_admins    = try(values.bucket_storage_admins, {})
+    set_hmac_key_admin_roles = try(values.set_hmac_key_admin_roles, false)
+    hmac_key_admins          = try(values.hmac_key_admins, [])
+    bucket_hmac_key_admins   = try(values.bucket_hmac_key_admins, {})
+    set_hmac_access          = try(values.set_hmac_access, false)
+    hmac_service_accounts    = try(values.hmac_service_accounts, {})
+  },
+  try(values.project_id, "") != "" ? { project_id = values.project_id } : {},
+  length(try(values.names, [])) > 0 ? { names = values.names } : {},
+)

--- a/mise.lock
+++ b/mise.lock
@@ -4,62 +4,196 @@
 version = "2.7.5"
 backend = "aqua:fluxcd/flux2"
 
+[tools."aqua:fluxcd/flux2"."platforms.linux-arm64"]
+checksum = "sha256:89d3ebb47ee5f7a0def33217e8dcb885e0bec41d01d0e23fc84e9aba0416c24e"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/321464054"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-arm64".provenance.slsa]
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/provenance.intoto.jsonl"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-arm64-musl"]
+checksum = "sha256:89d3ebb47ee5f7a0def33217e8dcb885e0bec41d01d0e23fc84e9aba0416c24e"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/321464054"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-arm64-musl".provenance.slsa]
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/provenance.intoto.jsonl"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-x64"]
+checksum = "sha256:1e92141e8498289e4b27411385aeb18396053176cf297b0cb99abd6ca8293e75"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/321464057"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-x64".provenance.slsa]
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/provenance.intoto.jsonl"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-x64-musl"]
+checksum = "sha256:1e92141e8498289e4b27411385aeb18396053176cf297b0cb99abd6ca8293e75"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/321464057"
+
+[tools."aqua:fluxcd/flux2"."platforms.linux-x64-musl".provenance.slsa]
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/provenance.intoto.jsonl"
+
+[tools."aqua:fluxcd/flux2"."platforms.macos-arm64"]
+checksum = "sha256:79faae964badc0b08f61ef6228f636bea99c6750537634855fa8b84f75b006d8"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/321464066"
+
+[tools."aqua:fluxcd/flux2"."platforms.macos-arm64".provenance.slsa]
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/provenance.intoto.jsonl"
+
 [tools."aqua:fluxcd/flux2"."platforms.macos-x64"]
 checksum = "sha256:2058b49ef38b5773b9aa87b3db83d68cbaf5082ecf908cbd8952a17f6af0e2e8"
 url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_darwin_amd64.tar.gz"
+
+[tools."aqua:fluxcd/flux2"."platforms.windows-x64"]
+checksum = "sha256:271537f7a70623344a60a749cbc7eb712faa83d1b095fc232b1dd17acadd01a1"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_windows_amd64.zip"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/321464071"
+
+[tools."aqua:fluxcd/flux2"."platforms.windows-x64".provenance.slsa]
+url = "https://github.com/fluxcd/flux2/releases/download/v2.7.5/provenance.intoto.jsonl"
 
 [[tools.kubectl]]
 version = "1.34.2"
 backend = "aqua:kubernetes/kubernetes/kubectl"
 
+[tools.kubectl."platforms.linux-arm64"]
+checksum = "sha256:95df604e914941f3172a93fa8feeb1a1a50f4011dfbe0c01e01b660afc8f9b85"
+url = "https://dl.k8s.io/v1.34.2/bin/linux/arm64/kubectl"
+
+[tools.kubectl."platforms.linux-arm64-musl"]
+checksum = "sha256:95df604e914941f3172a93fa8feeb1a1a50f4011dfbe0c01e01b660afc8f9b85"
+url = "https://dl.k8s.io/v1.34.2/bin/linux/arm64/kubectl"
+
+[tools.kubectl."platforms.linux-x64"]
+checksum = "sha256:9591f3d75e1581f3f7392e6ad119aab2f28ae7d6c6e083dc5d22469667f27253"
+url = "https://dl.k8s.io/v1.34.2/bin/linux/amd64/kubectl"
+
+[tools.kubectl."platforms.linux-x64-musl"]
+checksum = "sha256:9591f3d75e1581f3f7392e6ad119aab2f28ae7d6c6e083dc5d22469667f27253"
+url = "https://dl.k8s.io/v1.34.2/bin/linux/amd64/kubectl"
+
+[tools.kubectl."platforms.macos-arm64"]
+checksum = "sha256:8f38d3a38ae317b00ebf90254dc274dd28d8c6eea4a4b30c5cb12d3d27017b6d"
+url = "https://dl.k8s.io/v1.34.2/bin/darwin/arm64/kubectl"
+
 [tools.kubectl."platforms.macos-x64"]
 checksum = "sha256:d2a71bb7dd7238287f2ba4efefbad4f98584170063f7d9e6c842f772d9255d45"
 url = "https://dl.k8s.io/v1.34.2/bin/darwin/amd64/kubectl"
+
+[tools.kubectl."platforms.windows-x64"]
+checksum = "sha256:7d34dcc49a185d64194ff3e952d5621b7da4f5562fa83df5acf305bd1f7de9cc"
+url = "https://dl.k8s.io/v1.34.2/bin/windows/amd64/kubectl.exe"
 
 [[tools.opentofu]]
 version = "1.10.7"
 backend = "aqua:opentofu/opentofu"
 
+[tools.opentofu."platforms.linux-arm64"]
+checksum = "sha256:cfde76d660cbaa7b7b1ad1dab02fe99085f2fc7a2d2e7f9fd2ff4167358d52c0"
+url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/opentofu/opentofu/releases/assets/313304591"
+
+[tools.opentofu."platforms.linux-arm64-musl"]
+checksum = "sha256:cfde76d660cbaa7b7b1ad1dab02fe99085f2fc7a2d2e7f9fd2ff4167358d52c0"
+url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/opentofu/opentofu/releases/assets/313304591"
+
+[tools.opentofu."platforms.linux-x64"]
+checksum = "sha256:765a7374aeafcad15fe8da5359de76ce11ba0fd3cb6c2dc85d3b390e6362cae5"
+url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/opentofu/opentofu/releases/assets/313304587"
+
+[tools.opentofu."platforms.linux-x64-musl"]
+checksum = "sha256:765a7374aeafcad15fe8da5359de76ce11ba0fd3cb6c2dc85d3b390e6362cae5"
+url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/opentofu/opentofu/releases/assets/313304587"
+
+[tools.opentofu."platforms.macos-arm64"]
+checksum = "sha256:e5cdc6d0bdd85b0cf699f00e2cd547c3b3d0892c7b5ecb22bd02c72d9d1ff8bc"
+url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/opentofu/opentofu/releases/assets/313304608"
+
 [tools.opentofu."platforms.macos-x64"]
 checksum = "sha256:ec063e3920fab7cc80299f66d2fda3ec752f774b88caf3c207122336674843a3"
 url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_darwin_amd64.tar.gz"
 
+[tools.opentofu."platforms.windows-x64"]
+checksum = "sha256:58e9f247c57c7c1faef3b20fd735dcad272154e93bd02246eeff36cb756b03df"
+url = "https://github.com/opentofu/opentofu/releases/download/v1.10.7/tofu_1.10.7_windows_amd64.tar.gz"
+url_api = "https://api.github.com/repos/opentofu/opentofu/releases/assets/313304629"
+
 [[tools.pre-commit]]
 version = "4.5.0"
 backend = "aqua:pre-commit/pre-commit"
+
+[tools.pre-commit."platforms.linux-arm64"]
+checksum = "sha256:fbbfa47d19b98e03eb11963094ac3644a97cba105a8c660d8dab4c409c89cebe"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.0/pre-commit-4.5.0.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/319694381"
+
+[tools.pre-commit."platforms.linux-arm64-musl"]
+checksum = "sha256:fbbfa47d19b98e03eb11963094ac3644a97cba105a8c660d8dab4c409c89cebe"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.0/pre-commit-4.5.0.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/319694381"
+
+[tools.pre-commit."platforms.linux-x64"]
+checksum = "sha256:fbbfa47d19b98e03eb11963094ac3644a97cba105a8c660d8dab4c409c89cebe"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.0/pre-commit-4.5.0.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/319694381"
+
+[tools.pre-commit."platforms.linux-x64-musl"]
+checksum = "sha256:fbbfa47d19b98e03eb11963094ac3644a97cba105a8c660d8dab4c409c89cebe"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.0/pre-commit-4.5.0.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/319694381"
+
+[tools.pre-commit."platforms.macos-arm64"]
+checksum = "sha256:fbbfa47d19b98e03eb11963094ac3644a97cba105a8c660d8dab4c409c89cebe"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.0/pre-commit-4.5.0.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/319694381"
 
 [tools.pre-commit."platforms.macos-x64"]
 checksum = "sha256:fbbfa47d19b98e03eb11963094ac3644a97cba105a8c660d8dab4c409c89cebe"
 url = "https://github.com/pre-commit/pre-commit/releases/download/v4.5.0/pre-commit-4.5.0.pyz"
 
 [[tools.terragrunt]]
-version = "1.1.1"
+version = "1.1.2"
 backend = "aqua:gruntwork-io/terragrunt"
 
 [tools.terragrunt."platforms.linux-arm64"]
-checksum = "sha256:a374a7993ff3d99665a7e014007d3647ec7f0465c9d55c85e9f94c932e73cea2"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_linux_arm64.tar.gz"
+checksum = "sha256:7c8c4dda530779755df369651dee885f9a7cef8595e1186e80b365fb88f5f788"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494371772"
 
 [tools.terragrunt."platforms.linux-arm64-musl"]
-checksum = "sha256:a374a7993ff3d99665a7e014007d3647ec7f0465c9d55c85e9f94c932e73cea2"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_linux_arm64.tar.gz"
+checksum = "sha256:7c8c4dda530779755df369651dee885f9a7cef8595e1186e80b365fb88f5f788"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494371772"
 
 [tools.terragrunt."platforms.linux-x64"]
-checksum = "sha256:ce90077ac31ef17a2ba10d11d45f36c6501997a8f4f79d703bb7daba37032f53"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_linux_amd64.tar.gz"
+checksum = "sha256:ddb947f5e71ae036ca01449af3bf87828d4b2b18ffd411cbf8dd624d45e37a9e"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494371624"
 
 [tools.terragrunt."platforms.linux-x64-musl"]
-checksum = "sha256:ce90077ac31ef17a2ba10d11d45f36c6501997a8f4f79d703bb7daba37032f53"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_linux_amd64.tar.gz"
+checksum = "sha256:ddb947f5e71ae036ca01449af3bf87828d4b2b18ffd411cbf8dd624d45e37a9e"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494371624"
 
 [tools.terragrunt."platforms.macos-arm64"]
-checksum = "sha256:9ec8f678b9ae6c81d5d9d77b94cbf6349ce639d5938694b4adc9dea73e416794"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_darwin_arm64.tar.gz"
+checksum = "sha256:74239174818aae9f45e9aa6e8ec20f4efecd04afd7b752c552a42e96020cf761"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494371317"
 
 [tools.terragrunt."platforms.macos-x64"]
-checksum = "sha256:73e768a69fa44a60f9d9174f54aaf179327e08706f633c9c79d5f5c9622c91c2"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_darwin_amd64.tar.gz"
+checksum = "sha256:c43916d00f2f0a200173c51b40b39f63147835fac368c5d2754638698950a18d"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494371087"
 
 [tools.terragrunt."platforms.windows-x64"]
-checksum = "sha256:dd50a324691e072a3ac879e9ec43d6310e2936c929fda658eb2811fefcc75115"
-url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_windows_amd64.exe.tar.gz"
+checksum = "sha256:984765a0fc3c2d0e489d5d7f8bacd9c7f418ddc9a99859c5ed2458005d23dd8c"
+url = "https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.2/terragrunt_windows_amd64.exe.tar.gz"
+url_api = "https://api.github.com/repos/gruntwork-io/terragrunt/releases/assets/494372099"

--- a/mise.toml
+++ b/mise.toml
@@ -7,4 +7,4 @@ lockfile = true
 kubectl = "1.34.2"
 opentofu = "1.10.7"
 pre-commit = "4.5.0"
-terragrunt = "1.1.1"
+terragrunt = "1.1.2"


### PR DESCRIPTION
Add a Terragrunt catalog unit for creating GCS buckets, wrapping terraform-google-modules/cloud-storage/google v12.3.0.

- Add terragrunt.hcl with values.* scaffolding and conditional required inputs (project_id, names)
- Add README with scaffolding table, consumption examples, and cross-reference to iam/storage-bucket for IAM-only bindings