### PR TITLE
feat(gcp): add VPC and Cloud SQL PostgreSQL catalog units

### DIFF
--- a/iac/gcp/catalog/units/db/postgresql/README.md
+++ b/iac/gcp/catalog/units/db/postgresql/README.md
@@ -1,0 +1,293 @@
+<!-- Frontmatter
+name: GCP Cloud SQL PostgreSQL
+description: Create a Google Cloud SQL PostgreSQL instance.
+tags:
+  - unit
+  - gcp
+  - google
+  - database
+  - postgresql
+  - cloud-sql
+-->
+
+# GCP Cloud SQL PostgreSQL
+
+Creates a Google Cloud SQL PostgreSQL instance (with optional read replicas, databases, and users).
+
+This is a **Unit** component. It wraps the [terraform-google-modules/sql-db/google//modules/postgresql](https://registry.terraform.io/modules/terraform-google-modules/sql-db/google/28.2.0/submodules/postgresql) module (v28.2.0).
+
+> **Note:** For private IP access, create a VPC first with [`vpc`](../vpc/) and enable `private_service_access_config`, then set `ip_configuration.private_network` to the VPC `network_self_link` output in this unit.
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place and prompts for each `values.*` reference (press `x` on optional fields to keep the `try()` default). It writes a `terragrunt.values.hcl` with the answers you provide.
+
+| Value | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `project_id` | yes | — | Project ID where the Cloud SQL instance will be created. |
+| `name` | yes | — | Cloud SQL instance name. |
+| `database_version` | yes | — | PostgreSQL version (e.g. `POSTGRES_14`, `POSTGRES_15`, `POSTGRES_16`, `POSTGRES_17`). |
+| `region` | no | `"us-central1"` | Region for the Cloud SQL instance. |
+| `tier` | no | `"db-f1-micro"` | Machine tier (e.g. `db-f1-micro`, `db-custom-1-3840`, `db-perf-optimized-N-2`). |
+| `edition` | no | `null` | Instance edition (`ENTERPRISE` or `ENTERPRISE_PLUS`). |
+| `availability_type` | no | `"ZONAL"` | `ZONAL` or `REGIONAL` (HA). |
+| `zone` | no | `null` | Primary zone (e.g. `europe-west1-b`). |
+| `random_instance_name` | no | `false` | Append a random suffix to the instance name. |
+| `deletion_protection` | no | `true` | Block Terraform from deleting the instance. |
+| `enable_default_db` | no | `true` | Create the default database. |
+| `db_name` | no | `"default"` | Name of the default database. |
+| `enable_default_user` | no | `true` | Create the default user. |
+| `user_name` | no | `"default"` | Default database user name. |
+| `user_password` | no | `""` | Default user password (auto-generated when empty). |
+| `ip_configuration` | no | `{}` | Public/private IP, SSL, authorized networks, PSC settings. |
+| `backup_configuration` | no | `{}` | Automated backup settings. |
+| `read_replicas` | no | `[]` | Read replica definitions. |
+| `user_labels` | no | `{}` | Labels on the instance. |
+
+Set `project_id`, `name`, and `database_version` together when scaffolding a real instance.
+
+After scaffolding, wire the unit into your live repository and supply project-specific configuration there.
+
+In a stack `unit` block you only need to set the values you care about; optional keys use the `try()` defaults in the catalog unit. Required keys such as `project_id`, `name`, and `database_version` can be omitted from `values` when you supply them via an `autoinclude` `inputs` block instead (see [catalog units README](../../README.md)).
+
+## Consumption
+
+Include this unit from your live repository and supply module inputs in your `terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "postgresql" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/gcp/catalog/units/db/postgresql?ref=<version>"
+}
+
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id       = dependency.project.outputs.project_id
+  name             = "app-db"
+  database_version = "POSTGRES_15"
+  region           = "europe-west1"
+  tier             = "db-f1-micro"
+  deletion_protection = false
+}
+```
+
+Project-specific values (`project_id`, `name`, `region`, networking) belong in the **live** repository, not in the catalog.
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `project_id` | `string` | Project ID where the Cloud SQL instance will be created. |
+| `name` | `string` | Cloud SQL instance name. |
+| `database_version` | `string` | PostgreSQL version (e.g. `POSTGRES_14`, `POSTGRES_15`). |
+
+## Commonly set in live
+
+| Input | Notes |
+|-------|--------|
+| `region` / `zone` | Match your workload region and zone. |
+| `tier` / `edition` | Size and edition; use `ENTERPRISE_PLUS` with `db-perf-optimized-*` tiers when needed. |
+| `availability_type` | Set to `REGIONAL` for high availability. |
+| `ip_configuration` | Public IP with `authorized_networks`, or private IP via `private_network`. |
+| `backup_configuration` | Enable backups and point-in-time recovery for production. |
+| `deletion_protection` | Keep `true` in production; set `false` for ephemeral environments. |
+| `read_replicas` | Add read replicas for scaling reads. |
+| `user_password` | Prefer Secret Manager or a generated password over plain text in git. |
+
+## Optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `region` | `string` | `"us-central1"` | Region of the Cloud SQL resources. |
+| `edition` | `string` | `null` | `ENTERPRISE` or `ENTERPRISE_PLUS`. |
+| `maintenance_version` | `string` | `null` | Software maintenance version (updates trigger restart). |
+| `availability_type` | `string` | `"ZONAL"` | `ZONAL` or `REGIONAL`. |
+| `enable_default_db` | `bool` | `true` | Create the default database. |
+| `db_name` | `string` | `"default"` | Default database name. |
+| `enable_default_user` | `bool` | `true` | Create the default user. |
+| `user_name` | `string` | `"default"` | Default user name. |
+| `user_password` | `string` | `""` | Default user password (random when empty). |
+| `root_password` | `string` | `null` | Initial root password during creation. |
+| `deletion_protection` | `bool` | `true` | Block Terraform deletion. |
+| `database_flags` | `list(object)` | `[]` | PostgreSQL database flags. |
+| `database_deletion_policy` | `string` | `null` | Deletion policy for databases (`ABANDON`). |
+| `user_deletion_policy` | `string` | `null` | Deletion policy for users (`ABANDON`). |
+| `data_cache_enabled` | `bool` | `false` | Enable data cache (`ENTERPRISE_PLUS` only). |
+| `additional_users` | `list(object)` | `[]` | Extra users to create. |
+| `additional_databases` | `list(object)` | `[]` | Extra databases to create. |
+| `master_instance_name` | `string` | `null` | Master instance name for failover replica. |
+| `failover_dr_replica_name` | `string` | `null` | DR replica identifier for cross-region failover. |
+| `instance_type` | `string` | `"CLOUD_SQL_INSTANCE"` | Instance type (`READ_REPLICA_INSTANCE` when replicating). |
+| `random_instance_name` | `bool` | `false` | Random suffix on instance name. |
+| `tier` | `string` | `"db-f1-micro"` | Machine tier. |
+| `zone` | `string` | `null` | Primary zone. |
+| `secondary_zone` | `string` | `null` | Preferred zone for replica. |
+| `follow_gae_application` | `string` | `null` | GAE app whose zone to remain in. |
+| `activation_policy` | `string` | `"ALWAYS"` | `ALWAYS`, `NEVER`, or `ON_DEMAND`. |
+| `deletion_protection_enabled` | `bool` | `false` | Protection from accidental deletion across all surfaces. |
+| `read_replica_deletion_protection_enabled` | `bool` | `false` | Replica deletion protection across all surfaces. |
+| `disk_autoresize` | `bool` | `true` | Auto-increase disk size. |
+| `disk_autoresize_limit` | `number` | `0` | Max auto-resize disk size (GB). |
+| `disk_size` | `number` | `10` | Disk size in GB. |
+| `disk_type` | `string` | `"PD_SSD"` | Disk type. |
+| `pricing_plan` | `string` | `"PER_USE"` | Pricing plan. |
+| `maintenance_window_day` | `number` | `1` | Maintenance day (1–7). |
+| `maintenance_window_hour` | `number` | `23` | Maintenance hour (0–23). |
+| `maintenance_window_update_track` | `string` | `"canary"` | `canary` or `stable`. |
+| `user_labels` | `map(string)` | `{}` | Instance labels. |
+| `deny_maintenance_period` | `list(object)` | `[]` | Deny maintenance window. |
+| `backup_configuration` | `object` | `{}` | Backup settings. |
+| `final_backup_config` | `object` | `null` | Final backup on delete settings. |
+| `insights_config` | `object` | `null` | Query insights settings. |
+| `password_validation_policy_config` | `object` | `null` | Password policy settings. |
+| `ip_configuration` | `object` | `{}` | IP, SSL, authorized networks, PSC. |
+| `read_replicas` | `list(object)` | `[]` | Read replica configurations. |
+| `read_replica_name_suffix` | `string` | `""` | Suffix for read replica names. |
+| `db_charset` | `string` | `""` | Default database charset. |
+| `db_collation` | `string` | `""` | Default database collation. |
+| `iam_users` | `list(object)` | `[]` | IAM database users. |
+| `create_timeout` | `string` | `"30m"` | Create operation timeout. |
+| `update_timeout` | `string` | `"30m"` | Update operation timeout. |
+| `delete_timeout` | `string` | `"30m"` | Delete operation timeout. |
+| `encryption_key_name` | `string` | `null` | CMEK encryption key. |
+| `module_depends_on` | `list(any)` | `[]` | Explicit module dependencies. |
+| `read_replica_deletion_protection` | `bool` | `false` | Block Terraform replica deletion. |
+| `enable_random_password_special` | `bool` | `false` | Special chars in generated passwords. |
+| `connector_enforcement` | `bool` | `false` | Require Cloud SQL Auth Proxy / connector. |
+| `enable_google_ml_integration` | `bool` | `false` | Enable ML integration. |
+| `enable_dataplex_integration` | `bool` | `false` | Enable Dataplex integration. |
+| `database_integration_roles` | `list(string)` | `[]` | Roles for GCP service integration. |
+| `use_autokey` | `bool` | `false` | Use Cloud KMS autokeys for CMEK. |
+| `create_kms_key_handle` | `bool` | `true` | Create KMS key handle when using autokey. |
+| `kms_key_handle_name` | `string` | `null` | KMS key handle name override. |
+| `retain_backups_on_delete` | `bool` | `false` | Retain backups after instance deletion. |
+| `connection_pool_config` | `object` | `null` | Managed connection pool settings. |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/sql-db/google/28.2.0/submodules/postgresql?tab=inputs) for full details.
+
+## Examples
+
+### Public PostgreSQL instance
+
+Based on the [postgresql-public](https://github.com/terraform-google-modules/terraform-google-sql-db/tree/main/examples/postgresql-public) example:
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id         = dependency.project.outputs.project_id
+  name               = "app-db"
+  random_instance_name = true
+  database_version   = "POSTGRES_14"
+  region             = "europe-west1"
+  zone               = "europe-west1-b"
+  tier               = "db-f1-micro"
+  deletion_protection = false
+
+  ip_configuration = {
+    ipv4_enabled        = true
+    private_network     = null
+    ssl_mode            = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+    authorized_networks = []
+  }
+}
+```
+
+### Regional HA with backups and read replica
+
+Based on the [postgresql-ha](https://github.com/terraform-google-modules/terraform-google-sql-db/tree/main/examples/postgresql-ha) example:
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id       = dependency.project.outputs.project_id
+  name             = "app-db-ha"
+  database_version = "POSTGRES_15"
+  region           = "europe-west1"
+  tier             = "db-custom-1-3840"
+  zone             = "europe-west1-b"
+  availability_type = "REGIONAL"
+  deletion_protection = false
+
+  backup_configuration = {
+    enabled           = true
+    start_time        = "03:00"
+    retained_backups  = 7
+    retention_unit    = "COUNT"
+  }
+
+  ip_configuration = {
+    ipv4_enabled = true
+    ssl_mode     = "ENCRYPTED_ONLY"
+  }
+
+  read_replica_name_suffix = "-replica"
+  read_replicas = [
+    {
+      name              = "0"
+      zone              = "europe-west1-c"
+      availability_type = "REGIONAL"
+      tier              = "db-custom-1-3840"
+      disk_type         = "PD_SSD"
+      user_labels       = { role = "read-replica" }
+      ip_configuration = {
+        ipv4_enabled = true
+        ssl_mode     = "ENCRYPTED_ONLY"
+      }
+    }
+  ]
+}
+```
+
+### Private IP (requires VPC with PSA)
+
+Enable `private_service_access_config` on the [`vpc`](../vpc/) unit first, then:
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+dependency "vpc" {
+  config_path = "../../network/vpc"
+}
+
+inputs = {
+  project_id       = dependency.project.outputs.project_id
+  name             = "app-db-private"
+  database_version = "POSTGRES_15"
+  region           = "europe-west1"
+
+  ip_configuration = {
+    ipv4_enabled    = false
+    private_network = dependency.vpc.outputs.network_self_link
+  }
+}
+```
+
+## Outputs
+
+Common outputs from this module:
+
+| Output | Description |
+|--------|-------------|
+| `instance_name` | Master instance name. |
+| `instance_connection_name` | Connection name for Cloud SQL Auth Proxy / connectors. |
+| `public_ip_address` | Public IPv4 address (when enabled). |
+| `private_ip_address` | Private IPv4 address (when enabled). |
+| `generated_user_password` | Auto-generated default user password (sensitive). |
+| `read_replica_instance_names` | Read replica instance names. |
+| `env_vars` | Common connection environment variables. |
+
+See the [module outputs](https://registry.terraform.io/modules/terraform-google-modules/sql-db/google/28.2.0/submodules/postgresql?tab=outputs) for the full list.

--- a/iac/gcp/catalog/units/db/postgresql/terragrunt.hcl
+++ b/iac/gcp/catalog/units/db/postgresql/terragrunt.hcl
@@ -1,0 +1,87 @@
+/**
+ * Google Cloud SQL PostgreSQL unit.
+ *
+ * Wraps terraform-google-modules/sql-db/google//modules/postgresql.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl,
+ * or via `terragrunt.values.hcl` when scaffolding from the catalog (`values.*`).
+ */
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "tfr:///terraform-google-modules/sql-db/google//modules/postgresql?version=28.2.0"
+}
+
+inputs = merge(
+  {
+    region                                   = try(values.region, "us-central1")
+    edition                                  = try(values.edition, null)
+    maintenance_version                      = try(values.maintenance_version, null)
+    availability_type                        = try(values.availability_type, "ZONAL")
+    enable_default_db                        = try(values.enable_default_db, true)
+    db_name                                  = try(values.db_name, "default")
+    enable_default_user                      = try(values.enable_default_user, true)
+    user_name                                = try(values.user_name, "default")
+    user_password                            = try(values.user_password, "")
+    root_password                            = try(values.root_password, null)
+    deletion_protection                      = try(values.deletion_protection, true)
+    database_flags                           = try(values.database_flags, [])
+    database_deletion_policy                 = try(values.database_deletion_policy, null)
+    user_deletion_policy                     = try(values.user_deletion_policy, null)
+    data_cache_enabled                       = try(values.data_cache_enabled, false)
+    additional_users                         = try(values.additional_users, [])
+    additional_databases                     = try(values.additional_databases, [])
+    master_instance_name                     = try(values.master_instance_name, null)
+    failover_dr_replica_name                 = try(values.failover_dr_replica_name, null)
+    instance_type                            = try(values.instance_type, "CLOUD_SQL_INSTANCE")
+    random_instance_name                     = try(values.random_instance_name, false)
+    tier                                     = try(values.tier, "db-f1-micro")
+    zone                                     = try(values.zone, null)
+    secondary_zone                           = try(values.secondary_zone, null)
+    follow_gae_application                   = try(values.follow_gae_application, null)
+    activation_policy                        = try(values.activation_policy, "ALWAYS")
+    deletion_protection_enabled              = try(values.deletion_protection_enabled, false)
+    read_replica_deletion_protection_enabled = try(values.read_replica_deletion_protection_enabled, false)
+    disk_autoresize                          = try(values.disk_autoresize, true)
+    disk_autoresize_limit                    = try(values.disk_autoresize_limit, 0)
+    disk_size                                = try(values.disk_size, 10)
+    disk_type                                = try(values.disk_type, "PD_SSD")
+    pricing_plan                             = try(values.pricing_plan, "PER_USE")
+    maintenance_window_day                   = try(values.maintenance_window_day, 1)
+    maintenance_window_hour                  = try(values.maintenance_window_hour, 23)
+    maintenance_window_update_track          = try(values.maintenance_window_update_track, "canary")
+    user_labels                              = try(values.user_labels, {})
+    deny_maintenance_period                  = try(values.deny_maintenance_period, [])
+    backup_configuration                     = try(values.backup_configuration, {})
+    final_backup_config                      = try(values.final_backup_config, null)
+    insights_config                          = try(values.insights_config, null)
+    password_validation_policy_config        = try(values.password_validation_policy_config, null)
+    ip_configuration                         = try(values.ip_configuration, {})
+    read_replicas                            = try(values.read_replicas, [])
+    read_replica_name_suffix                 = try(values.read_replica_name_suffix, "")
+    db_charset                               = try(values.db_charset, "")
+    db_collation                             = try(values.db_collation, "")
+    iam_users                                = try(values.iam_users, [])
+    create_timeout                           = try(values.create_timeout, "30m")
+    update_timeout                           = try(values.update_timeout, "30m")
+    delete_timeout                           = try(values.delete_timeout, "30m")
+    encryption_key_name                      = try(values.encryption_key_name, null)
+    module_depends_on                        = try(values.module_depends_on, [])
+    read_replica_deletion_protection         = try(values.read_replica_deletion_protection, false)
+    enable_random_password_special           = try(values.enable_random_password_special, false)
+    connector_enforcement                    = try(values.connector_enforcement, false)
+    enable_google_ml_integration             = try(values.enable_google_ml_integration, false)
+    enable_dataplex_integration              = try(values.enable_dataplex_integration, false)
+    database_integration_roles               = try(values.database_integration_roles, [])
+    use_autokey                              = try(values.use_autokey, false)
+    create_kms_key_handle                    = try(values.create_kms_key_handle, true)
+    kms_key_handle_name                      = try(values.kms_key_handle_name, null)
+    retain_backups_on_delete                 = try(values.retain_backups_on_delete, false)
+    connection_pool_config                   = try(values.connection_pool_config, null)
+  },
+  try(values.project_id, "") != "" ? { project_id = values.project_id } : {},
+  try(values.name, "") != "" ? { name = values.name } : {},
+  try(values.database_version, "") != "" ? { database_version = values.database_version } : {},
+)

--- a/iac/gcp/catalog/units/vpc/README.md
+++ b/iac/gcp/catalog/units/vpc/README.md
@@ -1,0 +1,256 @@
+<!-- Frontmatter
+name: GCP VPC Network
+description: Create a Google Cloud VPC network with subnets, routes, and firewall rules.
+tags:
+  - unit
+  - gcp
+  - google
+  - vpc
+  - network
+-->
+
+# GCP VPC Network
+
+Creates a custom-mode VPC network with subnets, optional routes, firewall rules, and Private Service Access (PSA) peering for managed services such as Cloud SQL.
+
+This is a **Unit** component. It wraps the [terraform-google-modules/network/google](https://registry.terraform.io/modules/terraform-google-modules/network/google) module (v18.1.2).
+
+> **Note:** For private-IP Cloud SQL, enable `private_service_access_config` in this unit, then pass `network_self_link` to [`db/postgresql`](../db/postgresql/) via `ip_configuration.private_network`.
+
+## Scaffolding
+
+From the catalog TUI, select this unit and press `s` to scaffold it into your working directory. Terragrunt copies the unit files in place and prompts for each `values.*` reference (press `x` on optional fields to keep the `try()` default). It writes a `terragrunt.values.hcl` with the answers you provide.
+
+| Value | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `project_id` | yes | — | Project ID where the VPC will be created. |
+| `network_name` | yes | — | VPC network name. |
+| `subnets` | yes | — | List of subnet definitions (`subnet_name`, `subnet_ip`, `subnet_region`, …). |
+| `routing_mode` | no | `"GLOBAL"` | Network routing mode (`GLOBAL` or `REGIONAL`). |
+| `shared_vpc_host` | no | `false` | Make this project a Shared VPC host. |
+| `subnets_region` | no | `null` | Region for all subnets when not set per subnet. |
+| `secondary_ranges` | no | `{}` | Secondary IP ranges keyed by subnet name (e.g. for GKE pods). |
+| `routes` | no | `[]` | Custom routes in the VPC. |
+| `ingress_rules` | no | `[]` | Ingress firewall rules. |
+| `egress_rules` | no | `[]` | Egress firewall rules. |
+| `mtu` | no | `0` | Network MTU (`0` = provider default 1460). |
+| `private_service_access_config` | no | PSA disabled | Enable VPC peering for managed services (Cloud SQL private IP, etc.). |
+
+Set `project_id`, `network_name`, and `subnets` together when scaffolding a real VPC.
+
+After scaffolding, wire the unit into your live repository and supply project-specific configuration there.
+
+In a stack `unit` block you only need to set the values you care about; optional keys use the `try()` defaults in the catalog unit. Required keys such as `project_id`, `network_name`, and `subnets` can be omitted from `values` when you supply them via an `autoinclude` `inputs` block instead (see [catalog units README](../README.md)).
+
+## Consumption
+
+Include this unit from your live repository and supply module inputs in your `terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "vpc" {
+  path = "git::https://github.com/ywarezk/academeez-k8s-flux.git//iac/gcp/catalog/units/vpc?ref=<version>"
+}
+
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id   = dependency.project.outputs.project_id
+  network_name = "platform-vpc"
+  subnets = [
+    {
+      subnet_name   = "app"
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = "europe-west1"
+    }
+  ]
+}
+```
+
+Project-specific values (`project_id`, `network_name`, CIDR ranges, regions) belong in the **live** repository, not in the catalog.
+
+## Required inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `project_id` | `string` | Project ID where the VPC will be created. |
+| `network_name` | `string` | VPC network name. |
+| `subnets` | `list(object)` | Subnets to create (at least one for a usable custom-mode VPC). |
+
+## Commonly set in live
+
+| Input | Notes |
+|-------|--------|
+| `subnets` | Define CIDR blocks and regions for workloads (GKE, Cloud Run, VMs). |
+| `secondary_ranges` | Pod and service ranges for GKE clusters. |
+| `ingress_rules` / `egress_rules` | Restrict traffic to/from subnets. |
+| `shared_vpc_host` | Set `true` on the host project for Shared VPC. |
+| `private_service_access_config` | Enable before creating private-IP Cloud SQL in this VPC. |
+| `routes` | Custom egress or internal routing (e.g. via Cloud NAT or proxy). |
+
+## Optional inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `routing_mode` | `string` | `"GLOBAL"` | `GLOBAL` or `REGIONAL` routing. |
+| `shared_vpc_host` | `bool` | `false` | Shared VPC host project. |
+| `subnets_region` | `string` | `null` | Default region for all subnets. |
+| `secondary_ranges` | `map(list(object))` | `{}` | Secondary ranges per subnet name. |
+| `routes` | `list(object)` | `[]` | VPC routes. |
+| `firewall_rules` | `list(object)` | `[]` | Deprecated; use `ingress_rules` / `egress_rules`. |
+| `delete_default_internet_gateway_routes` | `bool` | `false` | Remove default internet gateway routes. |
+| `description` | `string` | `""` | VPC description. |
+| `auto_create_subnetworks` | `bool` | `false` | Auto subnet mode (not recommended for production). |
+| `mtu` | `number` | `0` | Network MTU (1300–8896; `0` = 1460). |
+| `ingress_rules` | `list(object)` | `[]` | Ingress firewall rules. |
+| `egress_rules` | `list(object)` | `[]` | Egress firewall rules. |
+| `enable_ipv6_ula` | `bool` | `false` | Enable IPv6 ULA (permanent). |
+| `internal_ipv6_range` | `string` | `null` | `/48` ULA range from `fd20::/20`. |
+| `network_firewall_policy_enforcement_order` | `string` | `null` | Firewall policy evaluation order. |
+| `network_profile` | `string` | `null` | Network profile URL. |
+| `bgp_always_compare_med` | `bool` | `false` | Cloud Router MED comparison. |
+| `bgp_best_path_selection_mode` | `string` | `"LEGACY"` | `STANDARD` or `LEGACY`. |
+| `bgp_inter_region_cost` | `string` | `null` | `DEFAULT` or `ADD_COST_TO_MED`. |
+| `private_service_access_config` | `object` | PSA disabled | PSA peering for managed services. |
+
+### `private_service_access_config`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable_private_services_connection` | `bool` | `false` | Create PSA peering to `servicenetworking.googleapis.com`. |
+| `address_name` | `string` | `"private-ip-address"` | Name of the reserved internal range. |
+| `prefix_length` | `number` | `16` | Size of the reserved range (e.g. `/16`). |
+
+See the [module inputs](https://registry.terraform.io/modules/terraform-google-modules/network/google/18.1.2?tab=inputs) for full details.
+
+## Examples
+
+### Basic VPC with two subnets
+
+Based on the [simple_project](https://github.com/terraform-google-modules/terraform-google-network/tree/v18.1.2/examples/simple_project) example:
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id   = dependency.project.outputs.project_id
+  network_name = "platform-vpc"
+  mtu          = 1460
+
+  subnets = [
+    {
+      subnet_name   = "app"
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = "europe-west1"
+    },
+    {
+      subnet_name           = "data"
+      subnet_ip             = "10.10.20.0/24"
+      subnet_region         = "europe-west1"
+      subnet_private_access = "true"
+      subnet_flow_logs      = "true"
+    }
+  ]
+}
+```
+
+### VPC with Private Service Access (for private Cloud SQL)
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id   = dependency.project.outputs.project_id
+  network_name = "platform-vpc"
+
+  subnets = [
+    {
+      subnet_name   = "app"
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = "europe-west1"
+    }
+  ]
+
+  private_service_access_config = {
+    enable_private_services_connection = true
+    address_name                       = "private-ip-address"
+    prefix_length                      = 16
+  }
+}
+```
+
+Then wire Cloud SQL to this VPC:
+
+```hcl
+dependency "vpc" {
+  config_path = "../../vpc"
+}
+
+inputs = {
+  # ... postgresql inputs ...
+  ip_configuration = {
+    ipv4_enabled    = false
+    private_network = dependency.vpc.outputs.network_self_link
+  }
+}
+```
+
+### GKE-ready VPC with secondary ranges
+
+```hcl
+dependency "project" {
+  config_path = "../../project"
+}
+
+inputs = {
+  project_id   = dependency.project.outputs.project_id
+  network_name = "gke-vpc"
+
+  subnets = [
+    {
+      subnet_name   = "gke-nodes"
+      subnet_ip     = "10.0.0.0/20"
+      subnet_region = "europe-west1"
+    }
+  ]
+
+  secondary_ranges = {
+    gke-nodes = [
+      {
+        range_name    = "gke-pods"
+        ip_cidr_range = "10.4.0.0/14"
+      },
+      {
+        range_name    = "gke-services"
+        ip_cidr_range = "10.8.0.0/20"
+      }
+    ]
+  }
+}
+```
+
+## Outputs
+
+Common outputs from this module:
+
+| Output | Description |
+|--------|-------------|
+| `network_name` | VPC name. |
+| `network_id` | VPC resource ID. |
+| `network_self_link` | VPC self link (use for `private_network` on Cloud SQL). |
+| `subnets` | Map of created subnets keyed by `region/name`. |
+| `subnets_names` | List of subnet names. |
+| `subnets_self_links` | List of subnet self links. |
+| `subnets_ips` | List of subnet CIDR blocks. |
+| `route_names` | Custom route names. |
+
+See the [module outputs](https://registry.terraform.io/modules/terraform-google-modules/network/google/18.1.2?tab=outputs) for the full list.

--- a/iac/gcp/catalog/units/vpc/README.md
+++ b/iac/gcp/catalog/units/vpc/README.md
@@ -154,8 +154,8 @@ inputs = {
       subnet_name           = "data"
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "europe-west1"
-      subnet_private_access = "true"
-      subnet_flow_logs      = "true"
+      subnet_private_access = true
+      subnet_flow_logs      = true
     }
   ]
 }

--- a/iac/gcp/catalog/units/vpc/terragrunt.hcl
+++ b/iac/gcp/catalog/units/vpc/terragrunt.hcl
@@ -1,0 +1,47 @@
+/**
+ * Google Cloud VPC network unit.
+ *
+ * Wraps terraform-google-modules/network/google.
+ * Consumers pass module inputs via the `inputs` block in live terragrunt.hcl,
+ * or via `terragrunt.values.hcl` when scaffolding from the catalog (`values.*`).
+ */
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "tfr:///terraform-google-modules/network/google?version=18.1.2"
+}
+
+inputs = merge(
+  {
+    routing_mode                              = try(values.routing_mode, "GLOBAL")
+    shared_vpc_host                           = try(values.shared_vpc_host, false)
+    subnets_region                            = try(values.subnets_region, null)
+    secondary_ranges                          = try(values.secondary_ranges, {})
+    routes                                    = try(values.routes, [])
+    firewall_rules                            = try(values.firewall_rules, [])
+    delete_default_internet_gateway_routes    = try(values.delete_default_internet_gateway_routes, false)
+    description                               = try(values.description, "")
+    auto_create_subnetworks                   = try(values.auto_create_subnetworks, false)
+    mtu                                       = try(values.mtu, 0)
+    ingress_rules                             = try(values.ingress_rules, [])
+    egress_rules                              = try(values.egress_rules, [])
+    enable_ipv6_ula                           = try(values.enable_ipv6_ula, false)
+    internal_ipv6_range                       = try(values.internal_ipv6_range, null)
+    network_firewall_policy_enforcement_order = try(values.network_firewall_policy_enforcement_order, null)
+    network_profile                           = try(values.network_profile, null)
+    bgp_always_compare_med                    = try(values.bgp_always_compare_med, false)
+    bgp_best_path_selection_mode              = try(values.bgp_best_path_selection_mode, "LEGACY")
+    bgp_inter_region_cost                     = try(values.bgp_inter_region_cost, null)
+    private_service_access_config = try(values.private_service_access_config, {
+      enable_private_services_connection = false
+      address_name                       = "private-ip-address"
+      prefix_length                      = 16
+    })
+  },
+  try(values.project_id, "") != "" ? { project_id = values.project_id } : {},
+  try(values.network_name, "") != "" ? { network_name = values.network_name } : {},
+  length(try(values.subnets, [])) > 0 ? { subnets = values.subnets } : {},
+)


### PR DESCRIPTION
## Summary

Adds two new Terragrunt catalog units under `iac/gcp/catalog/units/` for provisioning GCP networking and databases:

- **`vpc/`** — wraps [terraform-google-modules/network/google](https://registry.terraform.io/modules/terraform-google-modules/network/google) v18.1.2 to create a custom-mode VPC with subnets, routes, firewall rules, and optional **Private Service Access (PSA)** via `private_service_access_config`.
- **`db/postgresql/`** — wraps [terraform-google-modules/sql-db/google//modules/postgresql](https://registry.terraform.io/modules/terraform-google-modules/sql-db/google/28.2.0/submodules/postgresql) v28.2.0 to create a Cloud SQL PostgreSQL instance (with support for HA, backups, read replicas, and private IP).

Both units follow the existing catalog conventions: `values.*` scaffolding with `try()` defaults, conditional merges for required inputs, and README docs with consumption examples.

For private-IP Cloud SQL, PSA is bundled in the VPC unit for now (no separate PSA catalog unit). The documented flow is: provision VPC with `private_service_access_config` enabled → wire PostgreSQL via `ip_configuration.private_network = dependency.vpc.outputs.network_self_link`.

## What's included

| Unit | Module | Version |
|------|--------|---------|
| `units/vpc` | `terraform-google-modules/network/google` | 18.1.2 |
| `units/db/postgresql` | `terraform-google-modules/sql-db/google//modules/postgresql` | 28.2.0 |

## Test plan

- [ ] Run `terragrunt catalog` and verify both units appear with correct scaffolding prompts
- [ ] Scaffold `vpc` into a live path and run `terragrunt plan` with `project_id`, `network_name`, and `subnets`
- [ ] Scaffold `db/postgresql` and run `terragrunt plan` with `project_id`, `name`, and `database_version`
- [ ] (Optional) Plan a private-IP PostgreSQL stack: VPC with `private_service_access_config` enabled → PostgreSQL with `ip_configuration.private_network` wired to VPC output