### PR TITLE
fix(gcp): fix VPC catalog scaffolding error for private_service_acces…

### DIFF
--- a/iac/gcp/catalog/units/vpc/README.md
+++ b/iac/gcp/catalog/units/vpc/README.md
@@ -34,7 +34,7 @@ From the catalog TUI, select this unit and press `s` to scaffold it into your wo
 | `ingress_rules` | no | `[]` | Ingress firewall rules. |
 | `egress_rules` | no | `[]` | Egress firewall rules. |
 | `mtu` | no | `0` | Network MTU (`0` = provider default 1460). |
-| `private_service_access_config` | no | PSA disabled | Enable VPC peering for managed services (Cloud SQL private IP, etc.). |
+| `private_service_access_config` | no | PSA disabled (module default) | Enable VPC peering for managed services (Cloud SQL private IP, etc.). Press `x` when scaffolding to omit; add the full object in `terragrunt.values.hcl` when enabling PSA. |
 
 Set `project_id`, `network_name`, and `subnets` together when scaffolding a real VPC.
 

--- a/iac/gcp/catalog/units/vpc/terragrunt.hcl
+++ b/iac/gcp/catalog/units/vpc/terragrunt.hcl
@@ -39,5 +39,5 @@ inputs = merge(
   try(values.project_id, "") != "" ? { project_id = values.project_id } : {},
   try(values.network_name, "") != "" ? { network_name = values.network_name } : {},
   length(try(values.subnets, [])) > 0 ? { subnets = values.subnets } : {},
-  length(try(values.private_service_access_config, {})) > 0 ? { private_service_access_config = values.private_service_access_config } : {},
+  try(length(keys(values.private_service_access_config)), 0) > 0 ? { private_service_access_config = values.private_service_access_config } : {},
 )

--- a/iac/gcp/catalog/units/vpc/terragrunt.hcl
+++ b/iac/gcp/catalog/units/vpc/terragrunt.hcl
@@ -35,13 +35,9 @@ inputs = merge(
     bgp_always_compare_med                    = try(values.bgp_always_compare_med, false)
     bgp_best_path_selection_mode              = try(values.bgp_best_path_selection_mode, "LEGACY")
     bgp_inter_region_cost                     = try(values.bgp_inter_region_cost, null)
-    private_service_access_config = try(values.private_service_access_config, {
-      enable_private_services_connection = false
-      address_name                       = "private-ip-address"
-      prefix_length                      = 16
-    })
   },
   try(values.project_id, "") != "" ? { project_id = values.project_id } : {},
   try(values.network_name, "") != "" ? { network_name = values.network_name } : {},
   length(try(values.subnets, [])) > 0 ? { subnets = values.subnets } : {},
+  length(try(values.private_service_access_config, {})) > 0 ? { private_service_access_config = values.private_service_access_config } : {},
 )


### PR DESCRIPTION
…s_config

Terragrunt catalog failed when scaffolding the VPC unit with:

  missing attribute separator: Expected a newline or comma to mark the
  beginning of the next attribute.

The inline multi-line object default inside try() for private_service_access_config is not valid for catalog value discovery.

Move private_service_access_config to a conditional merge (same pattern as subnets): pass it only when set in values, otherwise rely on the network module default (PSA disabled). Update the README scaffolding note to document pressing x to skip and adding the full object when enabling PSA.